### PR TITLE
Present entries as real JSON from /latest.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ present a web interface on top.
 
 - Java 1.8+
 - Kafka 0.8.2+ to run standalone
+- Postgres DB 9.4
 
 # Build and Run project
 
 - Checkout project 
-- Use command `./gradlew cleanIdea idea` to generate the idea project files
+- Run the `./go` script to set everything up
 - Build project using command `./gradlew clean build` 

--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,10 @@ repositories {
 //noinspection GroovyAssignabilityCheck
 configurations {
     compile.exclude module: 'slf4j-log4j12'
+    compile.exclude module: 'slf4j-simple' // dropwizard uses logback, not slf4j-simple
 }
 dependencies {
-    compile dropwizard, kafka
+    compile dropwizard, kafka, postgresClient
 
     testCompile dropwizardTest, junit, kafkaTest, zkTest
 }

--- a/config.yaml
+++ b/config.yaml
@@ -1,1 +1,8 @@
+database:
+  driverClass: org.postgresql.Driver
+  url: jdbc:postgresql://localhost:5432/presentation
+  user: presentation
+  properties:
+    charSet: UTF-8
+
 zookeeperServer: localhost:2181

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -1,6 +1,7 @@
 ext{
-    dropwizard = 'io.dropwizard:dropwizard-core:0.8.1'
+    dropwizard = ['io.dropwizard:dropwizard-core:0.8.1','io.dropwizard:dropwizard-jdbi:0.8.1']
     kafka = 'org.apache.kafka:kafka_2.10:0.8.2.1'
+    postgresClient = 'org.postgresql:postgresql:9.4-1200-jdbc41'
 
     //test-dependencies
     dropwizardTest = ['io.dropwizard:dropwizard-client:0.8.1','io.dropwizard:dropwizard-testing:0.8.1']

--- a/go
+++ b/go
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -ue
+
+function ensure_db_exists {
+  psql -lqt | grep -wq $1 || createdb $1
+}
+
+function ensure_user_exists {
+  psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='$1'" | grep -q 1 || createuser $1
+}
+
+# Set up postgres
+ensure_db_exists presentation
+ensure_db_exists ft_presentation
+ensure_user_exists presentation
+ensure_user_exists ft_presentation
+
+# Set up IntelliJ
+if [ ! -f presentation.ipr ]; then
+  ./gradlew idea
+fi

--- a/src/main/java/uk/gov/register/presentation/JsonNodeMapper.java
+++ b/src/main/java/uk/gov/register/presentation/JsonNodeMapper.java
@@ -1,0 +1,24 @@
+package uk.gov.register.presentation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+
+import java.io.IOException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class JsonNodeMapper implements ResultSetMapper<JsonNode> {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public JsonNode map(int index, ResultSet r, StatementContext ctx) throws SQLException {
+        byte[] entry = r.getBytes("entry");
+        try {
+            return objectMapper.readValue(entry, JsonNode.class);
+        } catch (IOException e) {
+            throw new SQLException(e);
+        }
+    }
+}

--- a/src/main/java/uk/gov/register/presentation/PresentationConfiguration.java
+++ b/src/main/java/uk/gov/register/presentation/PresentationConfiguration.java
@@ -2,12 +2,25 @@ package uk.gov.register.presentation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
+import io.dropwizard.db.DataSourceFactory;
 import org.hibernate.validator.constraints.NotEmpty;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
 public class PresentationConfiguration extends Configuration implements ZookeeperConfiguration {
+    @Valid
+    @NotNull
+    @JsonProperty
+    private DataSourceFactory database;
+
     @NotEmpty
     @JsonProperty
     private String zookeeperServer;
+
+    public DataSourceFactory getDatabase() {
+        return database;
+    }
 
     public String getZookeeperServer() {
         return zookeeperServer;

--- a/src/main/java/uk/gov/register/presentation/PresentationResource.java
+++ b/src/main/java/uk/gov/register/presentation/PresentationResource.java
@@ -1,34 +1,24 @@
 package uk.gov.register.presentation;
 
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import java.nio.charset.Charset;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.List;
 
 @Path("/latest")
 @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
 public class PresentationResource {
-    private final AtomicReference<byte[]> currentLatest;
+    private final RecentEntryIndexQueryDAO queryDAO;
 
-    public PresentationResource(AtomicReference<byte[]> currentLatest) {
-
-        this.currentLatest = currentLatest;
+    public PresentationResource(RecentEntryIndexQueryDAO queryDAO) {
+        this.queryDAO = queryDAO;
     }
 
     @GET
-    public Response get() {
-        ArrayNode jsonNodes = new ArrayNode(new JsonNodeFactory(false));
-        byte[] latestMessage = currentLatest.get();
-        if (latestMessage == null) {
-            return Response.status(503).build();
-        }
-        jsonNodes.add(new String(latestMessage, Charset.forName("UTF-8")));
-        return Response.ok().entity(jsonNodes).build();
+    public List<JsonNode> get() {
+        return queryDAO.getLatestEntries(1);
     }
 }

--- a/src/main/java/uk/gov/register/presentation/RecentEntryIndexQueryDAO.java
+++ b/src/main/java/uk/gov/register/presentation/RecentEntryIndexQueryDAO.java
@@ -1,0 +1,14 @@
+package uk.gov.register.presentation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
+
+import java.util.List;
+
+public interface RecentEntryIndexQueryDAO {
+    @RegisterMapper(JsonNodeMapper.class)
+    @SqlQuery("SELECT entry FROM ordered_entry_index ORDER BY id DESC LIMIT :limit")
+    List<JsonNode> getLatestEntries(@Bind("limit") int maxNumberToFetch);
+}

--- a/src/main/java/uk/gov/register/presentation/RecentEntryIndexUpdateDAO.java
+++ b/src/main/java/uk/gov/register/presentation/RecentEntryIndexUpdateDAO.java
@@ -1,0 +1,12 @@
+package uk.gov.register.presentation;
+
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+
+public interface RecentEntryIndexUpdateDAO {
+    @SqlUpdate("CREATE TABLE IF NOT EXISTS ordered_entry_index (ID SERIAL PRIMARY KEY, ENTRY BYTEA)")
+    void ensureTableExists();
+
+    @SqlUpdate("INSERT INTO ordered_entry_index (ENTRY) VALUES (:entry)")
+    void append(@Bind("entry") byte[] entry);
+}

--- a/src/test/java/uk/gov/register/presentation/functional/FunctionalTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/FunctionalTest.java
@@ -12,7 +12,6 @@ import uk.gov.register.presentation.PresentationConfiguration;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
-import java.util.Arrays;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -31,13 +30,13 @@ public class FunctionalTest {
 
     @Test
     public void shouldConsumeMessageFromKafkaAndShowAsLatest() throws Exception {
-        String message = "foo";
+        String message = "{\"foo\":\"bar\"}";
         testKafkaCluster.getProducer().send(new ProducerRecord<>(TOPIC, message.getBytes()));
         waitForAppToConsumeMessage();
 
         Response response = client.target(String.format("http://localhost:%d/latest.json", RULE.getLocalPort())).request().get();
 
-        assertThat(response.readEntity(String.class), equalTo("[\"foo\"]"));
+        assertThat(response.readEntity(String.class), equalTo("[{\"foo\":\"bar\"}]"));
 
     }
 

--- a/src/test/resources/test-app-config.yaml
+++ b/src/test/resources/test-app-config.yaml
@@ -1,1 +1,16 @@
+server:
+  applicationConnectors:
+    - type: http
+      port: 9000
+  adminConnectors:
+    - type: http
+      port: 9001
+
+database:
+  driverClass: org.postgresql.Driver
+  url: jdbc:postgresql://localhost:5432/ft_presentation
+  user: ft_presentation
+  properties:
+    charSet: UTF-8
+
 zookeeperServer: PLACEHOLDER


### PR DESCRIPTION
Before openregister/mint#7, we had no guarantee the incoming entries on
the kafka stream were legitimately JSON; so we were just treating them
as raw bytes to shove into a JSON string.  ie for message `foo`, we
would return JSON `["foo"]`.

This meant that when we got real JSON, we would embed it into a JSON
string.  That is, the message `{"foo":"bar"}` would return JSON
`["{\"foo\":\"bar\"}"]` rather than the desired `[{"foo":"bar"}]`.

This PR treats asserts that all incoming messages are JSON, and they
should be entered into a local postgres index.  Then, the
PresentationResource can get the latest message from the index.

This uses [dropwizard-jdbi](https://dropwizard.github.io/dropwizard/manual/jdbi.html) for data access.  This provides an
advantage that the DBI objects it provides are managed by dropwizard and
will be started and shut down according to Dropwizard's lifecycle.  It
also allows database access through a nicely declarative interface.
