### PR TITLE
Show multiple entries in /latest.json

### DIFF
--- a/src/main/java/uk/gov/register/presentation/PresentationResource.java
+++ b/src/main/java/uk/gov/register/presentation/PresentationResource.java
@@ -11,6 +11,7 @@ import java.util.List;
 @Path("/latest")
 @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
 public class PresentationResource {
+    public static final int ENTRY_LIMIT = 100;
     private final RecentEntryIndexQueryDAO queryDAO;
 
     public PresentationResource(RecentEntryIndexQueryDAO queryDAO) {
@@ -19,6 +20,6 @@ public class PresentationResource {
 
     @GET
     public List<JsonNode> get() {
-        return queryDAO.getLatestEntries(1);
+        return queryDAO.getLatestEntries(ENTRY_LIMIT);
     }
 }

--- a/src/test/java/uk/gov/register/presentation/functional/CleanDatabaseRule.java
+++ b/src/test/java/uk/gov/register/presentation/functional/CleanDatabaseRule.java
@@ -1,0 +1,25 @@
+package uk.gov.register.presentation.functional;
+
+import org.junit.rules.ExternalResource;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+
+public class CleanDatabaseRule extends ExternalResource {
+    private final String tableName;
+    private final String pgUrl;
+
+    public CleanDatabaseRule(String pgUrl, String tableName) {
+        this.tableName = tableName;
+        this.pgUrl = pgUrl;
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        Connection connection = DriverManager.getConnection(pgUrl);
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("DROP TABLE IF EXISTS " + tableName);
+        }
+    }
+}

--- a/src/test/java/uk/gov/register/presentation/functional/FunctionalTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/FunctionalTest.java
@@ -1,5 +1,6 @@
 package uk.gov.register.presentation.functional;
 
+import com.google.common.collect.ImmutableList;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
@@ -7,36 +8,45 @@ import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import uk.gov.register.presentation.PresentationApplication;
 import uk.gov.register.presentation.PresentationConfiguration;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class FunctionalTest {
-    public static final String TOPIC = "register";
+    public static final String DATABASE_URL = "jdbc:postgresql://localhost:5432/ft_presentation";
 
+    public static final String TOPIC = "register";
     private static final TestKafkaCluster testKafkaCluster = new TestKafkaCluster(TOPIC);
+
+    @ClassRule
+    public static final TestRule cleanDb = new CleanDatabaseRule(DATABASE_URL, "ordered_entry_index");
 
     @ClassRule
     public static final DropwizardAppRule<PresentationConfiguration> RULE =
             new DropwizardAppRule<>(PresentationApplication.class,
                     ResourceHelpers.resourceFilePath("test-app-config.yaml"),
-                    ConfigOverride.config("zookeeperServer","localhost:" + testKafkaCluster.getZkPort()));
+                    ConfigOverride.config("zookeeperServer", "localhost:" + testKafkaCluster.getZkPort()),
+                    ConfigOverride.config("database.url", DATABASE_URL));
     private final Client client = new JerseyClientBuilder(RULE.getEnvironment()).build("test client");
 
     @Test
     public void shouldConsumeMessageFromKafkaAndShowAsLatest() throws Exception {
-        String message = "{\"foo\":\"bar\"}";
-        testKafkaCluster.getProducer().send(new ProducerRecord<>(TOPIC, message.getBytes()));
+        List<String> messages = ImmutableList.of("{\"foo\":\"version1\"}", "{\"fred\":\"jim\"}", "{\"foo\":\"version2\"}");
+        for (String message : messages) {
+            testKafkaCluster.getProducer().send(new ProducerRecord<>(TOPIC, message.getBytes()));
+        }
         waitForAppToConsumeMessage();
 
         Response response = client.target(String.format("http://localhost:%d/latest.json", RULE.getLocalPort())).request().get();
 
-        assertThat(response.readEntity(String.class), equalTo("[{\"foo\":\"bar\"}]"));
+        assertThat(response.readEntity(String.class), equalTo("[{\"foo\":\"version2\"},{\"fred\":\"jim\"},{\"foo\":\"version1\"}]"));
 
     }
 

--- a/src/test/resources/test-app-config.yaml
+++ b/src/test/resources/test-app-config.yaml
@@ -8,7 +8,7 @@ server:
 
 database:
   driverClass: org.postgresql.Driver
-  url: jdbc:postgresql://localhost:5432/ft_presentation
+  url: PLACEHOLDER
   user: ft_presentation
   properties:
     charSet: UTF-8


### PR DESCRIPTION
PR #1 started displaying JSON properly at /latest.json.  This PR ensures
that we can present more than one entry.

To do this, I needed to update FunctionalTest to clean the database each
time.  Because @BeforeClass methods run after TestRule setup, and we
needed to clean the database before starting the app, I needed to create
a new TestRule for cleaning the database.

Because the CleanDatabaseRule needs the db connection url, I've pulled
it out of the yaml file into the FunctionalTest class.
