### PR TITLE
don't assume default platform charset, be explicit instead

### DIFF
--- a/src/main/java/uk/gov/register/presentation/app/ConsumerRunnable.java
+++ b/src/main/java/uk/gov/register/presentation/app/ConsumerRunnable.java
@@ -12,6 +12,7 @@ import uk.gov.register.presentation.config.ZookeeperConfiguration;
 import uk.gov.register.presentation.dao.PGObjectFactory;
 import uk.gov.register.presentation.dao.RecentEntryIndexUpdateDAO;
 
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -46,7 +47,7 @@ public class ConsumerRunnable implements Runnable {
         for (MessageAndMetadata<String, byte[]> messageAndMetadata : kafkaStream) {
             byte[] message = messageAndMetadata.message();
             //TODO: check can we directly get getBytes into string
-            updateDAO.append(PGObjectFactory.jsonbObject(new String(message)));
+            updateDAO.append(PGObjectFactory.jsonbObject(new String(message, Charset.forName("UTF-8"))));
         }
     }
 


### PR DESCRIPTION
The javadoc for new String(bytes[]) says:

> Constructs a new String by decoding the specified array of bytes using
> the platform's default charset.

Rather than hoping that the platform's default charset will be UTF-8, we
should explicitly specify that UTF-8 is the required charset.
