### PR TITLE
Escaping csv and tsv entries

### DIFF
--- a/src/main/java/uk/gov/register/presentation/entity/CsvEntity.java
+++ b/src/main/java/uk/gov/register/presentation/entity/CsvEntity.java
@@ -11,6 +11,8 @@ import java.util.stream.Collectors;
 
 class CsvEntity implements Entity {
 
+    private static final String csvLineSeparator = "\r\n";
+
     @SuppressWarnings("unchecked")
     @Override
     public Object convert(AbstractView view) {
@@ -23,7 +25,7 @@ class CsvEntity implements Entity {
 
             headerElements = headerElements(list.get(0));
 
-            data = list.stream().map(e -> getCsvData(headerElements, e)).collect(Collectors.joining("\n"));
+            data = list.stream().map(e -> getCsvData(headerElements, e)).collect(Collectors.joining(csvLineSeparator));
         } else {
             Map map = JsonObjectMapper.convert(view.get(), Map.class);
 
@@ -33,7 +35,7 @@ class CsvEntity implements Entity {
         }
 
 
-        return String.join(entrySeparator(), headerElements) + "\n" + data;
+        return String.join(entrySeparator(), headerElements) + csvLineSeparator + data;
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/uk/gov/register/presentation/entity/CsvEntity.java
+++ b/src/main/java/uk/gov/register/presentation/entity/CsvEntity.java
@@ -1,18 +1,15 @@
 package uk.gov.register.presentation.entity;
 
+import org.apache.commons.lang3.StringEscapeUtils;
 import uk.gov.register.presentation.mapper.JsonObjectMapper;
 import uk.gov.register.presentation.view.AbstractView;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 class CsvEntity implements Entity {
-
-    private final String separator;
-
-    public CsvEntity(String separator) {
-        this.separator = separator;
-    }
 
     @SuppressWarnings("unchecked")
     @Override
@@ -36,30 +33,36 @@ class CsvEntity implements Entity {
         }
 
 
-        return String.join(separator, headerElements) + "\n" + data;
+        return String.join(entrySeparator(), headerElements) + "\n" + data;
     }
 
-    private List<String> headerElements(Map map){
+    @SuppressWarnings("unchecked")
+    private List<String> headerElements(Map map) {
         List<String> headerElements = new ArrayList<>();
         headerElements.add("hash");
         headerElements.addAll(((Map) map.get("entry")).keySet());
         return headerElements;
     }
 
+    @SuppressWarnings("unchecked")
     private String getCsvData(List<String> headerElements, Map map) {
-        Map entry = (Map) map.get("entry");
+        Map<String, Object> entry = (Map) map.get("entry");
         entry.put("hash", map.get("hash"));
 
-        return headerElements.stream().map(e -> (String) entry.get(e)).collect(Collectors.joining(separator));
+        return headerElements.stream().map(e -> escape((String) entry.get(e))).collect(Collectors.joining(entrySeparator()));
     }
 
     @Override
     public String contentType() {
-        if(separator.equals(",")){
-            return "text/csv";
-        }else{
-            return "text/tsv";
-        }
+        return "text/csv; charset=utf-8";
+    }
+
+    protected String escape(String data) {
+        return StringEscapeUtils.escapeCsv(data);
+    }
+
+    protected String entrySeparator(){
+        return ",";
     }
 }
 

--- a/src/main/java/uk/gov/register/presentation/entity/Representation.java
+++ b/src/main/java/uk/gov/register/presentation/entity/Representation.java
@@ -1,8 +1,8 @@
 package uk.gov.register.presentation.entity;
 
 public enum Representation{
-    csv(new CsvEntity(",")),
-    tsv(new CsvEntity("\t")),
+    csv(new CsvEntity()),
+    tsv(new TsvEntity()),
     html(new HtmlEntity()),
     json(new JsonEntity());
 

--- a/src/main/java/uk/gov/register/presentation/entity/TsvEntity.java
+++ b/src/main/java/uk/gov/register/presentation/entity/TsvEntity.java
@@ -1,0 +1,27 @@
+package uk.gov.register.presentation.entity;
+
+import org.apache.commons.lang3.StringEscapeUtils;
+
+class TsvEntity extends CsvEntity {
+    private static final String QUOTE = "\"";
+
+    @Override
+    protected String escape(String data) {
+        String escapedData = StringEscapeUtils.escapeCsv(data);
+        if (escapedData.contains(entrySeparator()) && escapedData.equals(StringEscapeUtils.unescapeCsv(escapedData))) {
+            return QUOTE + escapedData + QUOTE;
+        } else {
+            return escapedData;
+        }
+    }
+
+    @Override
+    public String contentType() {
+        return "text/tab-separated-values; charset=utf-8";
+    }
+
+    @Override
+    protected String entrySeparator(){
+        return "\t";
+    }
+}

--- a/src/test/java/uk/gov/register/presentation/entity/CsvEntityTest.java
+++ b/src/test/java/uk/gov/register/presentation/entity/CsvEntityTest.java
@@ -31,7 +31,7 @@ public class CsvEntityTest {
         AbstractView view = new SingleResultView("foo", node);
         Object result = csvEntity.convert(view);
 
-        assertThat(result.toString(), equalTo("hash,key1,key2,key3,key4\nhash1,valu\te1,\"val,ue2\",\"val\"\"ue3\",\"val\nue4\""));
+        assertThat(result.toString(), equalTo("hash,key1,key2,key3,key4\r\nhash1,valu\te1,\"val,ue2\",\"val\"\"ue3\",\"val\nue4\""));
     }
 
 }

--- a/src/test/java/uk/gov/register/presentation/entity/CsvEntityTest.java
+++ b/src/test/java/uk/gov/register/presentation/entity/CsvEntityTest.java
@@ -1,0 +1,37 @@
+package uk.gov.register.presentation.entity;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import uk.gov.register.presentation.mapper.JsonObjectMapper;
+import uk.gov.register.presentation.view.AbstractView;
+import uk.gov.register.presentation.view.SingleResultView;
+
+import java.util.Map;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class CsvEntityTest {
+    @Test
+    public void csv_entriesAreEscaped() {
+        CsvEntity csvEntity = new CsvEntity();
+
+        Map jsonMap = ImmutableMap.of(
+                "hash", "hash1",
+                "entry", ImmutableMap.of(
+                        "key1", "valu\te1",
+                        "key2", "val,ue2",
+                        "key3", "val\"ue3",
+                        "key4", "val\nue4"
+                )
+        );
+        JsonNode node = JsonObjectMapper.convert(jsonMap, JsonNode.class);
+
+        AbstractView view = new SingleResultView("foo", node);
+        Object result = csvEntity.convert(view);
+
+        assertThat(result.toString(), equalTo("hash,key1,key2,key3,key4\nhash1,valu\te1,\"val,ue2\",\"val\"\"ue3\",\"val\nue4\""));
+    }
+
+}

--- a/src/test/java/uk/gov/register/presentation/entity/TsvEntityTest.java
+++ b/src/test/java/uk/gov/register/presentation/entity/TsvEntityTest.java
@@ -1,0 +1,38 @@
+package uk.gov.register.presentation.entity;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import uk.gov.register.presentation.mapper.JsonObjectMapper;
+import uk.gov.register.presentation.view.AbstractView;
+import uk.gov.register.presentation.view.SingleResultView;
+
+import java.util.Map;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class TsvEntityTest {
+    @Test
+    public void tsv_entriesAreEscaped() {
+        TsvEntity csvEntity = new TsvEntity();
+
+
+        Map jsonMap = ImmutableMap.of(
+                "hash", "hash1",
+                "entry", ImmutableMap.of(
+                        "key1", "value1",
+                        "key2", "val\tue2",
+                        "key3", "val\"ue3",
+                        "key4", "val\nue4"
+                )
+        );
+        JsonNode node = JsonObjectMapper.convert(jsonMap, JsonNode.class);
+
+        AbstractView view = new SingleResultView("someTemplate", node);
+        Object result = csvEntity.convert(view);
+
+        assertThat(result.toString(), equalTo("hash\tkey1\tkey2\tkey3\tkey4\nhash1\tvalue1\t\"val\tue2\"\t\"val\"\"ue3\"\t\"val\nue4\""));
+    }
+
+}

--- a/src/test/java/uk/gov/register/presentation/entity/TsvEntityTest.java
+++ b/src/test/java/uk/gov/register/presentation/entity/TsvEntityTest.java
@@ -32,7 +32,7 @@ public class TsvEntityTest {
         AbstractView view = new SingleResultView("someTemplate", node);
         Object result = csvEntity.convert(view);
 
-        assertThat(result.toString(), equalTo("hash\tkey1\tkey2\tkey3\tkey4\nhash1\tvalue1\t\"val\tue2\"\t\"val\"\"ue3\"\t\"val\nue4\""));
+        assertThat(result.toString(), equalTo("hash\tkey1\tkey2\tkey3\tkey4\r\nhash1\tvalue1\t\"val\tue2\"\t\"val\"\"ue3\"\t\"val\nue4\""));
     }
 
 }

--- a/src/test/java/uk/gov/register/presentation/functional/CsvRepresentationTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/CsvRepresentationTest.java
@@ -24,7 +24,7 @@ public class CsvRepresentationTest extends FunctionalTestBase{
         Response response = getRequest("/hash/hash1.csv");
 
         assertThat(response.getHeaderString("Content-Type"), equalTo("text/csv; charset=utf-8"));
-        assertThat(response.readEntity(String.class), equalTo("hash,name,ft_test_pkey\nhash1,ellis,\"123,45\""));
+        assertThat(response.readEntity(String.class), equalTo("hash,name,ft_test_pkey\r\nhash1,ellis,\"123,45\""));
     }
 
     @Test
@@ -32,7 +32,7 @@ public class CsvRepresentationTest extends FunctionalTestBase{
         Response response = getRequest("/all.csv");
 
         assertThat(response.getHeaderString("Content-Type"), equalTo("text/csv; charset=utf-8"));
-        assertThat(response.readEntity(String.class), equalTo("hash,name,ft_test_pkey\nhash2,presley,6789\nhash3,ellis,145678\nhash1,ellis,\"123,45\""));
+        assertThat(response.readEntity(String.class), equalTo("hash,name,ft_test_pkey\r\nhash2,presley,6789\r\nhash3,ellis,145678\r\nhash1,ellis,\"123,45\""));
     }
 
     @Test
@@ -40,7 +40,7 @@ public class CsvRepresentationTest extends FunctionalTestBase{
         Response response = getRequest("/hash/hash1.tsv");
 
         assertThat(response.getHeaderString("Content-Type"), equalTo("text/tab-separated-values; charset=utf-8"));
-        assertThat(response.readEntity(String.class), equalTo("hash\tname\tft_test_pkey\nhash1\tellis\t\"123,45\""));
+        assertThat(response.readEntity(String.class), equalTo("hash\tname\tft_test_pkey\r\nhash1\tellis\t\"123,45\""));
     }
 
     @Test
@@ -48,6 +48,6 @@ public class CsvRepresentationTest extends FunctionalTestBase{
         Response response = getRequest("/all.tsv");
 
         assertThat(response.getHeaderString("Content-Type"), equalTo("text/tab-separated-values; charset=utf-8"));
-        assertThat(response.readEntity(String.class), equalTo("hash\tname\tft_test_pkey\nhash2\tpresley\t6789\nhash3\tellis\t145678\nhash1\tellis\t\"123,45\""));
+        assertThat(response.readEntity(String.class), equalTo("hash\tname\tft_test_pkey\r\nhash2\tpresley\t6789\r\nhash3\tellis\t145678\r\nhash1\tellis\t\"123,45\""));
     }
 }

--- a/src/test/java/uk/gov/register/presentation/functional/CsvRepresentationTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/CsvRepresentationTest.java
@@ -13,7 +13,7 @@ public class CsvRepresentationTest extends FunctionalTestBase{
     @BeforeClass
     public static void publishTestMessages() {
         publishMessagesToDB(ImmutableList.of(
-                "{\"hash\":\"hash1\",\"entry\":{\"name\":\"ellis\",\"ft_test_pkey\":\"12345\"}}",
+                "{\"hash\":\"hash1\",\"entry\":{\"name\":\"ellis\",\"ft_test_pkey\":\"123,45\"}}",
                 "{\"hash\":\"hash2\",\"entry\":{\"name\":\"presley\",\"ft_test_pkey\":\"6789\"}}",
                 "{\"hash\":\"hash3\",\"entry\":{\"name\":\"ellis\",\"ft_test_pkey\":\"145678\"}}"
         ));
@@ -23,31 +23,31 @@ public class CsvRepresentationTest extends FunctionalTestBase{
     public void csvRepresentationIsSupportedForAnEntry() {
         Response response = getRequest("/hash/hash1.csv");
 
-        assertThat(response.getHeaderString("Content-Type"), equalTo("text/csv"));
-        assertThat(response.readEntity(String.class), equalTo("hash,name,ft_test_pkey\nhash1,ellis,12345"));
+        assertThat(response.getHeaderString("Content-Type"), equalTo("text/csv; charset=utf-8"));
+        assertThat(response.readEntity(String.class), equalTo("hash,name,ft_test_pkey\nhash1,ellis,\"123,45\""));
     }
 
     @Test
     public void csvRepresentationIsSupportedForEntries() {
         Response response = getRequest("/all.csv");
 
-        assertThat(response.getHeaderString("Content-Type"), equalTo("text/csv"));
-        assertThat(response.readEntity(String.class), equalTo("hash,name,ft_test_pkey\nhash2,presley,6789\nhash3,ellis,145678\nhash1,ellis,12345"));
+        assertThat(response.getHeaderString("Content-Type"), equalTo("text/csv; charset=utf-8"));
+        assertThat(response.readEntity(String.class), equalTo("hash,name,ft_test_pkey\nhash2,presley,6789\nhash3,ellis,145678\nhash1,ellis,\"123,45\""));
     }
 
     @Test
     public void tsvRepresentationIsSupportedForAnEntry() {
         Response response = getRequest("/hash/hash1.tsv");
 
-        assertThat(response.getHeaderString("Content-Type"), equalTo("text/tsv"));
-        assertThat(response.readEntity(String.class), equalTo("hash\tname\tft_test_pkey\nhash1\tellis\t12345"));
+        assertThat(response.getHeaderString("Content-Type"), equalTo("text/tab-separated-values; charset=utf-8"));
+        assertThat(response.readEntity(String.class), equalTo("hash\tname\tft_test_pkey\nhash1\tellis\t\"123,45\""));
     }
 
     @Test
     public void tsvRepresentationIsSupportedForEntries() {
         Response response = getRequest("/all.tsv");
 
-        assertThat(response.getHeaderString("Content-Type"), equalTo("text/tsv"));
-        assertThat(response.readEntity(String.class), equalTo("hash\tname\tft_test_pkey\nhash2\tpresley\t6789\nhash3\tellis\t145678\nhash1\tellis\t12345"));
+        assertThat(response.getHeaderString("Content-Type"), equalTo("text/tab-separated-values; charset=utf-8"));
+        assertThat(response.readEntity(String.class), equalTo("hash\tname\tft_test_pkey\nhash2\tpresley\t6789\nhash3\tellis\t145678\nhash1\tellis\t\"123,45\""));
     }
 }


### PR DESCRIPTION
Refactored the CsvEntity class in two classes, one for Csv representation and second for tsv representation. Earlier implementation was not escaping any data.
