### PR TITLE
return 404 for non-primary-key path

### DIFF
--- a/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
@@ -42,7 +42,7 @@ public class SearchResource extends ResourceBase {
             return buildResponse(new SingleResultView("/templates/entry.mustache", entry.isPresent() ? entry.get() : null));
         }
 
-        throw new BadRequestException("Key: " + key + " is not primary key of the register.");
+        throw new NotFoundException();
     }
 
     @GET

--- a/src/test/java/uk/gov/register/presentation/functional/FindEntityTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/FindEntityTest.java
@@ -31,7 +31,7 @@ public class FindEntityTest extends FunctionalTestBase {
     public void findByPrimaryKey_returns400ForNonPrimaryKeySearch() {
         Response response = getRequest("/key1/key1Value_1.json");
 
-        assertThat(response.getStatus(), equalTo(400));
+        assertThat(response.getStatus(), equalTo(404));
 
     }
 

--- a/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
@@ -7,7 +7,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotFoundException;
 
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
@@ -29,7 +29,7 @@ public class SearchResourceTest {
         try {
             resource.findByPrimaryKey("someOtherKey", "value");
             fail("Must fail");
-        } catch (BadRequestException e) {
+        } catch (NotFoundException e) {
             //success
         }
     }


### PR DESCRIPTION
We have defined resources for `/hash/<value>` and `/<primary-key>/<value>`.
Any other path is not defined.  The http way to respond that a path is
not recognized is to say 404 Not Found.
