### PR TITLE
Simplify representation code

### DIFF
--- a/src/main/java/uk/gov/register/presentation/Entry.java
+++ b/src/main/java/uk/gov/register/presentation/Entry.java
@@ -1,0 +1,26 @@
+package uk.gov.register.presentation;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class Entry {
+    private final String hash;
+    private final JsonNode content;
+
+    @JsonCreator
+    public Entry(@JsonProperty("hash") String hash, @JsonProperty("entry") JsonNode content) {
+        this.hash = hash;
+        this.content = content;
+    }
+
+    @JsonProperty
+    public String getHash() {
+        return hash;
+    }
+
+    @JsonProperty("entry")
+    public JsonNode getContent() {
+        return content;
+    }
+}

--- a/src/main/java/uk/gov/register/presentation/dao/RecentEntryIndexQueryDAO.java
+++ b/src/main/java/uk/gov/register/presentation/dao/RecentEntryIndexQueryDAO.java
@@ -6,6 +6,8 @@ import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
 import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
+import uk.gov.register.presentation.Entry;
+import uk.gov.register.presentation.mapper.EntryMapper;
 import uk.gov.register.presentation.mapper.JsonNodeMapper;
 
 import java.util.List;
@@ -17,15 +19,17 @@ public interface RecentEntryIndexQueryDAO {
     List<JsonNode> getFeeds(@Bind("limit") int maxNumberToFetch);
 
     @SqlQuery("SELECT entry FROM ordered_entry_index WHERE (entry #>> ARRAY['entry',:key]) = :value ORDER BY id DESC limit 1")
-    @SingleValueResult(JsonNode.class)
-    Optional<JsonNode> findByKeyValue(@Bind("key") String key, @Bind("value") String value);
+    @SingleValueResult(Entry.class)
+    @RegisterMapper(EntryMapper.class)
+    Optional<Entry> findByKeyValue(@Bind("key") String key, @Bind("value") String value);
 
     @SqlQuery("SELECT entry FROM ordered_entry_index WHERE (entry #>> ARRAY['entry',:key]) = :value ORDER BY id DESC")
     List<JsonNode> findAllByKeyValue(@Bind("key") String key, @Bind("value") String value);
 
     @SqlQuery("SELECT entry FROM ordered_entry_index WHERE (entry #>> ARRAY['hash']) = :hash")
-    @SingleValueResult(JsonNode.class)
-    Optional<JsonNode> findByHash(@Bind("hash") String hash);
+    @SingleValueResult(Entry.class)
+    @RegisterMapper(EntryMapper.class)
+    Optional<Entry> findByHash(@Bind("hash") String hash);
 
     @SqlQuery("SELECT i.id, i.entry FROM ordered_entry_index i, ( " +
             "SELECT MAX(id) AS id " +

--- a/src/main/java/uk/gov/register/presentation/mapper/EntryMapper.java
+++ b/src/main/java/uk/gov/register/presentation/mapper/EntryMapper.java
@@ -1,0 +1,29 @@
+package uk.gov.register.presentation.mapper;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Throwables;
+import io.dropwizard.jackson.Jackson;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+import uk.gov.register.presentation.Entry;
+
+import java.io.IOException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class EntryMapper implements ResultSetMapper<Entry> {
+    private final ObjectMapper objectMapper;
+
+    public EntryMapper() {
+        objectMapper = Jackson.newObjectMapper();
+    }
+
+    @Override
+    public Entry map(int index, ResultSet r, StatementContext ctx) throws SQLException {
+        try {
+            return objectMapper.readValue(r.getBytes("entry"), Entry.class);
+        } catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+}

--- a/src/main/java/uk/gov/register/presentation/representations/CsvWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/CsvWriter.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Iterators;
 import com.google.common.reflect.TypeToken;
 import org.apache.commons.lang3.StringEscapeUtils;
+import uk.gov.register.presentation.view.ListResultView;
 
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
@@ -20,22 +21,21 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Produces(ExtraMediaType.TEXT_CSV)
-public class CsvWriter implements MessageBodyWriter<List<JsonNode>> {
+public class CsvWriter implements MessageBodyWriter<ListResultView> {
     @Override
     public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
-        Type listOfJsonNode = new TypeToken<List<JsonNode>>() {
-        }.getType();
-        return genericType.equals(listOfJsonNode);
+        return ListResultView.class.isAssignableFrom(type);
     }
 
     @Override
-    public long getSize(List<JsonNode> jsonNodes, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    public long getSize(ListResultView listResultView, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
         // deprecated and ignored by Jersey 2. Returning -1 as per javadoc in the interface
         return -1;
     }
 
     @Override
-    public void writeTo(List<JsonNode> jsonNodes, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
+    public void writeTo(ListResultView view, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
+        List<JsonNode> jsonNodes = view.get();
         List<String> headers = getHeaders(jsonNodes.get(0));
         entityStream.write((String.join(",", headers) + "\r\n").getBytes("utf-8"));
         for (JsonNode jsonNode : jsonNodes) {

--- a/src/main/java/uk/gov/register/presentation/representations/ListResultJsonSerializer.java
+++ b/src/main/java/uk/gov/register/presentation/representations/ListResultJsonSerializer.java
@@ -1,0 +1,19 @@
+package uk.gov.register.presentation.representations;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import uk.gov.register.presentation.view.ListResultView;
+
+import java.io.IOException;
+import java.util.List;
+
+public class ListResultJsonSerializer extends JsonSerializer<ListResultView> {
+    @Override
+    public void serialize(ListResultView value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        List<JsonNode> jsonNodes = value.get();
+        JsonSerializer<Object> listSerializer = serializers.findValueSerializer(List.class);
+        listSerializer.serialize(jsonNodes, gen, serializers);
+    }
+}

--- a/src/main/java/uk/gov/register/presentation/representations/TsvWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/TsvWriter.java
@@ -3,7 +3,7 @@ package uk.gov.register.presentation.representations;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Iterators;
-import com.google.common.reflect.TypeToken;
+import uk.gov.register.presentation.view.ListResultView;
 
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
@@ -19,21 +19,21 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Produces(ExtraMediaType.TEXT_TSV)
-public class TsvWriter implements MessageBodyWriter<List<JsonNode>> {
+public class TsvWriter implements MessageBodyWriter<ListResultView> {
     @Override
     public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
-        Type listOfJsonNode = new TypeToken<List<JsonNode>>() {}.getType();
-        return genericType.equals(listOfJsonNode);
+        return ListResultView.class.isAssignableFrom(type);
     }
 
     @Override
-    public long getSize(List<JsonNode> jsonNodes, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    public long getSize(ListResultView view, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
         // deprecated and ignored by Jersey 2. Returning -1 as per javadoc in the interface
         return -1;
     }
 
     @Override
-    public void writeTo(List<JsonNode> jsonNodes, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
+    public void writeTo(ListResultView view, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
+        List<JsonNode> jsonNodes = view.get();
         List<String> headers = getHeaders(jsonNodes.get(0));
         entityStream.write((String.join("\t", headers) + "\n").getBytes("utf-8"));
         for (JsonNode jsonNode : jsonNodes) {

--- a/src/main/java/uk/gov/register/presentation/resource/DataResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/DataResource.java
@@ -28,14 +28,14 @@ public class DataResource extends ResourceBase {
 
     @GET
     @Path("/all")
-    @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV})
+    @Produces({MediaType.APPLICATION_JSON})
     public List<JsonNode> all() {
         return queryDAO.getAllEntries(getRegisterPrimaryKey(), ENTRY_LIMIT);
     }
 
     @GET
     @Path("/all")
-    @Produces()
+    @Produces({MediaType.TEXT_HTML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV})
     public ListResultView allHtml() {
         return new ListResultView("/templates/entries.mustache", all());
     }

--- a/src/main/java/uk/gov/register/presentation/resource/DataResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/DataResource.java
@@ -1,6 +1,5 @@
 package uk.gov.register.presentation.resource;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
 import uk.gov.register.presentation.representations.ExtraMediaType;
 import uk.gov.register.presentation.view.ListResultView;
@@ -9,7 +8,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import java.util.List;
 
 @Path("/")
 public class DataResource extends ResourceBase {
@@ -22,22 +20,15 @@ public class DataResource extends ResourceBase {
     @GET
     @Path("/feed")
     @Produces({MediaType.APPLICATION_JSON})
-    public List<JsonNode> feed() {
-        return queryDAO.getFeeds(ENTRY_LIMIT);
+    public ListResultView feed() {
+        return new ListResultView("/templates/entries.mustache", queryDAO.getFeeds(ENTRY_LIMIT));
     }
 
     @GET
     @Path("/all")
-    @Produces({MediaType.APPLICATION_JSON})
-    public List<JsonNode> all() {
-        return queryDAO.getAllEntries(getRegisterPrimaryKey(), ENTRY_LIMIT);
-    }
-
-    @GET
-    @Path("/all")
-    @Produces({MediaType.TEXT_HTML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV})
-    public ListResultView allHtml() {
-        return new ListResultView("/templates/entries.mustache", all());
+    @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV})
+    public ListResultView all() {
+        return new ListResultView("/templates/entries.mustache", queryDAO.getAllEntries(getRegisterPrimaryKey(), ENTRY_LIMIT));
     }
 
 }

--- a/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
@@ -1,6 +1,5 @@
 package uk.gov.register.presentation.resource;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Optional;
 import uk.gov.register.presentation.Entry;
 import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
@@ -9,7 +8,6 @@ import uk.gov.register.presentation.view.SingleResultView;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.*;
-import java.util.List;
 
 
 @Path("/")
@@ -23,23 +21,16 @@ public class SearchResource extends ResourceBase {
 
     @GET
     @Path("search")
-    @Produces(MediaType.APPLICATION_JSON)
-    public List<JsonNode> search(@Context UriInfo uriInfo) {
+    @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON})
+    public ListResultView search(@Context UriInfo uriInfo) {
         final MultivaluedMap<String, String> queryParameters = uriInfo.getQueryParameters();
 
-        return queryParameters.entrySet()
-                                .stream()
-                                .findFirst()
-                                .map(e -> queryDAO.findAllByKeyValue(e.getKey(), e.getValue().get(0)))
-                                .orElseGet(() -> queryDAO.getAllEntries(getRegisterPrimaryKey(), ENTRY_LIMIT));
-    }
-
-    @GET
-    @Path("search")
-    @Produces(MediaType.TEXT_HTML)
-    public ListResultView searchHtml(@Context UriInfo uriInfo) {
         return new ListResultView("/templates/entries.mustache",
-                        search(uriInfo));
+                queryParameters.entrySet()
+                        .stream()
+                        .findFirst()
+                        .map(e -> queryDAO.findAllByKeyValue(e.getKey(), e.getValue().get(0)))
+                        .orElseGet(() -> queryDAO.getAllEntries(getRegisterPrimaryKey(), ENTRY_LIMIT)));
     }
 
     @GET

--- a/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
@@ -2,6 +2,7 @@ package uk.gov.register.presentation.resource;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Optional;
+import uk.gov.register.presentation.Entry;
 import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
 import uk.gov.register.presentation.view.ListResultView;
 import uk.gov.register.presentation.view.SingleResultView;
@@ -43,24 +44,11 @@ public class SearchResource extends ResourceBase {
 
     @GET
     @Path("/{primaryKey}/{primaryKeyValue}")
-    @Produces(MediaType.APPLICATION_JSON)
-    public JsonNode findByPrimaryKey(@PathParam("primaryKey") String key, @PathParam("primaryKeyValue") String value) {
+    @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON})
+    public SingleResultView findByPrimaryKey(@PathParam("primaryKey") String key, @PathParam("primaryKeyValue") String value) {
         String registerPrimaryKey = getRegisterPrimaryKey();
         if (key.equals(registerPrimaryKey)) {
-            Optional<JsonNode> entry = queryDAO.findByKeyValue(key, value);
-            return entry.orNull();
-        }
-
-        throw new NotFoundException();
-    }
-
-    @GET
-    @Path("/{primaryKey}/{primaryKeyValue}")
-    @Produces(MediaType.TEXT_HTML)
-    public SingleResultView findByPrimaryKeyHtml(@PathParam("primaryKey") String key, @PathParam("primaryKeyValue") String value) {
-        String registerPrimaryKey = getRegisterPrimaryKey();
-        if (key.equals(registerPrimaryKey)) {
-            return new SingleResultView("/templates/entry.mustache", findByPrimaryKey(key, value));
+            return new SingleResultView("/templates/entry.mustache", queryDAO.findByKeyValue(key, value).orNull());
         }
 
         throw new NotFoundException();
@@ -68,16 +56,9 @@ public class SearchResource extends ResourceBase {
 
     @GET
     @Path("/hash/{hash}")
-    @Produces(MediaType.APPLICATION_JSON)
-    public JsonNode findByHash(@PathParam("hash") String hash) {
-        return queryDAO.findByHash(hash).orNull();
-    }
-
-    @GET
-    @Path("/hash/{hash}")
-    @Produces(MediaType.TEXT_HTML)
+    @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON})
     public SingleResultView findByHashHtml(@PathParam("hash") String hash) {
-        Optional<JsonNode> entry = queryDAO.findByHash(hash);
-        return new SingleResultView("/templates/entry.mustache", entry.isPresent() ? entry.get() : null);
+        Optional<Entry> entry = queryDAO.findByHash(hash);
+        return new SingleResultView("/templates/entry.mustache", entry.orNull());
     }
 }

--- a/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
@@ -48,7 +48,10 @@ public class SearchResource extends ResourceBase {
     public SingleResultView findByPrimaryKey(@PathParam("primaryKey") String key, @PathParam("primaryKeyValue") String value) {
         String registerPrimaryKey = getRegisterPrimaryKey();
         if (key.equals(registerPrimaryKey)) {
-            return new SingleResultView("/templates/entry.mustache", queryDAO.findByKeyValue(key, value).orNull());
+            Optional<Entry> entry = queryDAO.findByKeyValue(key, value);
+            if (entry.isPresent()) {
+                return new SingleResultView("/templates/entry.mustache", entry.get());
+            }
         }
 
         throw new NotFoundException();
@@ -57,8 +60,11 @@ public class SearchResource extends ResourceBase {
     @GET
     @Path("/hash/{hash}")
     @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON})
-    public SingleResultView findByHashHtml(@PathParam("hash") String hash) {
+    public SingleResultView findByHash(@PathParam("hash") String hash) {
         Optional<Entry> entry = queryDAO.findByHash(hash);
-        return new SingleResultView("/templates/entry.mustache", entry.orNull());
+        if (entry.isPresent()) {
+            return new SingleResultView("/templates/entry.mustache", entry.orNull());
+        }
+        throw new NotFoundException();
     }
 }

--- a/src/main/java/uk/gov/register/presentation/view/ListResultView.java
+++ b/src/main/java/uk/gov/register/presentation/view/ListResultView.java
@@ -1,13 +1,16 @@
 package uk.gov.register.presentation.view;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import uk.gov.register.presentation.mapper.JsonObjectMapper;
+import uk.gov.register.presentation.representations.ListResultJsonSerializer;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@JsonSerialize(using = ListResultJsonSerializer.class)
 public class ListResultView extends AbstractView<List<JsonNode>> {
     private final List<JsonNode> jsonNodes;
 

--- a/src/main/java/uk/gov/register/presentation/view/SingleResultView.java
+++ b/src/main/java/uk/gov/register/presentation/view/SingleResultView.java
@@ -1,27 +1,31 @@
 package uk.gov.register.presentation.view;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
-import uk.gov.register.presentation.mapper.JsonObjectMapper;
-
-import java.util.Map;
-import java.util.Set;
+import uk.gov.register.presentation.Entry;
 
 public class SingleResultView extends AbstractView<JsonNode> {
-    public final Set entry;
-    private final JsonNode jsonNode;
+    private final String hash;
+    private final JsonNode content;
 
-    public SingleResultView(String templateName, JsonNode jsonNode) {
+    public SingleResultView(String templateName, Entry entry) {
         super(templateName);
-        this.jsonNode = jsonNode;
-        this.entry = ((Map) JsonObjectMapper.convert(jsonNode, Map.class).get("entry")).entrySet();
+        this.hash = entry.getHash();
+        this.content = entry.getContent();
     }
 
     @Override
     public JsonNode get() {
-        return jsonNode;
+        return content;
     }
 
+    @JsonProperty
     public String getHash() {
-        return jsonNode.get("hash").textValue();
+        return hash;
+    }
+
+    @JsonProperty
+    public JsonNode getEntry() {
+        return content;
     }
 }

--- a/src/test/java/uk/gov/register/presentation/representations/CsvWriterTest.java
+++ b/src/test/java/uk/gov/register/presentation/representations/CsvWriterTest.java
@@ -2,15 +2,13 @@ package uk.gov.register.presentation.representations;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 import org.junit.Test;
 import uk.gov.register.presentation.mapper.JsonObjectMapper;
+import uk.gov.register.presentation.view.ListResultView;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.lang.reflect.Type;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -33,8 +31,7 @@ public class CsvWriterTest {
         JsonNode node = JsonObjectMapper.convert(jsonMap, JsonNode.class);
 
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
-        Type listJsonNodeType = new TypeToken<List<JsonNode>>() {}.getType();
-        writer.writeTo(Collections.singletonList(node), List.class, listJsonNodeType, null, ExtraMediaType.TEXT_CSV_TYPE, null, stream);
+        writer.writeTo(new ListResultView("don't care", Collections.singletonList(node)), ListResultView.class, null, null, ExtraMediaType.TEXT_CSV_TYPE, null, stream);
         String result = stream.toString("utf-8");
 
         assertThat(result, equalTo("hash,key1,key2,key3,key4\r\nhash1,valu\te1,\"val,ue2\",\"val\"\"ue3\",\"val\nue4\"\r\n"));

--- a/src/test/java/uk/gov/register/presentation/representations/SingleResultViewJsonTest.java
+++ b/src/test/java/uk/gov/register/presentation/representations/SingleResultViewJsonTest.java
@@ -1,0 +1,35 @@
+package uk.gov.register.presentation.representations;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jackson.Jackson;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import uk.gov.register.presentation.Entry;
+import uk.gov.register.presentation.view.SingleResultView;
+
+import java.io.StringWriter;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class SingleResultViewJsonTest {
+
+    private static ObjectMapper objectMapper;
+
+    @BeforeClass
+    public static void setUpOnce() throws Exception {
+        objectMapper = Jackson.newObjectMapper();
+    }
+
+    @Test
+    public void shouldSerializeSingleResultViewToJson() throws Exception {
+        Entry entry = new Entry("hash1", objectMapper.readValue(
+                "{\"school\":\"100000\",\"name\":\"My School\"}", JsonNode.class));
+        StringWriter writer = new StringWriter();
+        objectMapper.writeValue(writer, new SingleResultView("don't care", entry));
+        String result = writer.toString();
+        assertThat(objectMapper.readValue(result, JsonNode.class),
+                equalTo(objectMapper.readValue("{\"entry\":{\"name\":\"My School\",\"school\":\"100000\"},\"hash\":\"hash1\"}",JsonNode.class)));
+    }
+}

--- a/src/test/java/uk/gov/register/presentation/representations/TsvWriterTest.java
+++ b/src/test/java/uk/gov/register/presentation/representations/TsvWriterTest.java
@@ -2,13 +2,12 @@ package uk.gov.register.presentation.representations;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
 import org.junit.Test;
 import uk.gov.register.presentation.mapper.JsonObjectMapper;
+import uk.gov.register.presentation.view.ListResultView;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -34,8 +33,7 @@ public class TsvWriterTest {
         JsonNode node = JsonObjectMapper.convert(jsonMap, JsonNode.class);
 
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
-        Type listJsonNodeType = new TypeToken<List<JsonNode>>() {}.getType();
-        writer.writeTo(Collections.singletonList(node), List.class, listJsonNodeType, null, ExtraMediaType.TEXT_CSV_TYPE, null, stream);
+        writer.writeTo(new ListResultView("don't care", Collections.singletonList(node)), List.class, null, null, ExtraMediaType.TEXT_CSV_TYPE, null, stream);
         String result = stream.toString("utf-8");
 
         assertThat(result, equalTo("hash\tkey1\tkey2\tkey3\tkey4\nhash1\tvalue1\tvalue2\tval\"ue3\tvalue4\n"));

--- a/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
@@ -1,9 +1,11 @@
 package uk.gov.register.presentation.resource;
 
+import com.google.common.base.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.register.presentation.Entry;
 import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
 
 import javax.servlet.http.HttpServletRequest;
@@ -21,7 +23,7 @@ public class SearchResourceTest {
     HttpServletRequest httpServletRequest;
 
     @Test
-    public void findByPrimaryKey_throwsBadRequestException_whenSearchedKeyIsNotPrimaryKeyOfRegister() {
+    public void findByPrimaryKey_throwsNotFoundException_whenSearchedKeyIsNotPrimaryKeyOfRegister() {
         SearchResource resource = new SearchResource(queryDAO);
         resource.httpServletRequest = httpServletRequest;
 
@@ -34,4 +36,34 @@ public class SearchResourceTest {
         }
     }
 
+    @Test
+    public void findByPrimaryKey_throwsNotFoundException_whenSearchedKeyIsNotFound() {
+        SearchResource resource = new SearchResource(queryDAO);
+        resource.httpServletRequest = httpServletRequest;
+
+        when(httpServletRequest.getRequestURL()).thenReturn(new StringBuffer("http://school.openregister.org/school/value"));
+        when(queryDAO.findByKeyValue("school", "value")).thenReturn(Optional.<Entry>absent());
+        try {
+            resource.findByPrimaryKey("school", "value");
+            fail("Must fail");
+        } catch (NotFoundException e) {
+            //success
+        }
+    }
+
+
+    @Test
+    public void findByHash_throwsNotFoundWhenHashIsNotFound() {
+        SearchResource resource = new SearchResource(queryDAO);
+        resource.httpServletRequest = httpServletRequest;
+
+        when(httpServletRequest.getRequestURL()).thenReturn(new StringBuffer("http://school.openregister.org/hash/123"));
+        when(queryDAO.findByHash("123")).thenReturn(Optional.<Entry>absent());
+        try {
+            resource.findByHash("123");
+            fail("Must fail");
+        } catch (NotFoundException e) {
+            //success
+        }
+    }
 }


### PR DESCRIPTION
This makes is so that we only ever serialize a View object, regardless of representation.  Previously, the html representations consumed Views, but the json, csv, and tsv representations consumed JsonNodes and List<JsonNode>s.
