### PR TITLE
ensure /search and /feed support csv and tsv

### DIFF
--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -18,7 +18,7 @@ ext {
             "io.dropwizard:dropwizard-testing:${dropwizard_version}"
     ]
 
-    junit = 'junit:junit:4.12'
+    junit = ['junit:junit:4.12','org.hamcrest:hamcrest-library:1.3']
 
     kafkaTest = [
             'org.apache.kafka:kafka-clients:0.8.2.1',

--- a/src/main/java/uk/gov/register/presentation/resource/DataResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/DataResource.java
@@ -19,7 +19,7 @@ public class DataResource extends ResourceBase {
 
     @GET
     @Path("/feed")
-    @Produces({MediaType.APPLICATION_JSON})
+    @Produces({MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV})
     public ListResultView feed() {
         return new ListResultView("/templates/entries.mustache", queryDAO.getFeeds(ENTRY_LIMIT));
     }

--- a/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
@@ -3,6 +3,7 @@ package uk.gov.register.presentation.resource;
 import com.google.common.base.Optional;
 import uk.gov.register.presentation.Entry;
 import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
+import uk.gov.register.presentation.representations.ExtraMediaType;
 import uk.gov.register.presentation.view.ListResultView;
 import uk.gov.register.presentation.view.SingleResultView;
 
@@ -21,7 +22,7 @@ public class SearchResource extends ResourceBase {
 
     @GET
     @Path("search")
-    @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON})
+    @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV})
     public ListResultView search(@Context UriInfo uriInfo) {
         final MultivaluedMap<String, String> queryParameters = uriInfo.getQueryParameters();
 

--- a/src/test/java/uk/gov/register/presentation/resource/DataResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/DataResourceTest.java
@@ -1,0 +1,26 @@
+package uk.gov.register.presentation.resource;
+
+import org.junit.Test;
+import uk.gov.register.presentation.representations.ExtraMediaType;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+
+public class DataResourceTest {
+    @Test
+    public void feedSupportsJsonCsvTsv() throws Exception {
+        Method feedMethod = DataResource.class.getDeclaredMethod("feed");
+        List<String> declaredMediaTypes = asList(feedMethod.getAnnotation(Produces.class).value());
+        assertThat(declaredMediaTypes, hasItems(
+                MediaType.APPLICATION_JSON,
+                ExtraMediaType.TEXT_CSV,
+                ExtraMediaType.TEXT_TSV
+        ));
+    }
+}

--- a/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
@@ -1,16 +1,29 @@
 package uk.gov.register.presentation.resource;
 
 import com.google.common.base.Optional;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.register.presentation.Entry;
 import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
+import uk.gov.register.presentation.representations.ExtraMediaType;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriInfo;
 
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItemInArray;
+import static org.hamcrest.Matchers.hasItems;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 
@@ -65,5 +78,16 @@ public class SearchResourceTest {
         } catch (NotFoundException e) {
             //success
         }
+    }
+
+    @Test
+    public void searchSupportsCsvTsvHtmlAndJson() throws Exception {
+        Method searchMethod = SearchResource.class.getDeclaredMethod("search", UriInfo.class);
+        List<String> declaredMediaTypes = asList(searchMethod.getDeclaredAnnotation(Produces.class).value());
+        assertThat(declaredMediaTypes,
+                hasItems(MediaType.TEXT_HTML,
+                         MediaType.APPLICATION_JSON,
+                         ExtraMediaType.TEXT_CSV,
+                         ExtraMediaType.TEXT_TSV));
     }
 }


### PR DESCRIPTION
We already know that we can serialize a ListResultView to csv and tsv
because of /all.csv; so we can use a tiny unit test to test that the
right annotations are supported.
