### PR TITLE
Fix primary key assumption

### DIFF
--- a/src/main/java/uk/gov/register/presentation/resource/ResourceBase.java
+++ b/src/main/java/uk/gov/register/presentation/resource/ResourceBase.java
@@ -2,7 +2,6 @@ package uk.gov.register.presentation.resource;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Context;
-import java.net.URI;
 
 public abstract class ResourceBase {
     public static final int ENTRY_LIMIT = 100;
@@ -12,16 +11,12 @@ public abstract class ResourceBase {
     //Note: copied the logic to fetch primary key from alpha register.
     //Note: We might need to change the logic of extracting register primary key for beta registers
     protected String getRegisterPrimaryKey() {
-        try {
-            String host = new URI(httpServletRequest.getRequestURL().toString()).getHost();
+        String host = httpServletRequest.getHeader("Host");
 
-            if (host.contains(".")) {
-                return host.substring(0, host.indexOf("."));
-            } else {
-                return host;
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+        if (host.contains(".")) {
+            return host.substring(0, host.indexOf("."));
+        } else {
+            return host;
         }
     }
 }

--- a/src/main/java/uk/gov/register/presentation/resource/ResourceBase.java
+++ b/src/main/java/uk/gov/register/presentation/resource/ResourceBase.java
@@ -15,10 +15,7 @@ public abstract class ResourceBase {
         try {
             String host = new URI(httpServletRequest.getRequestURL().toString()).getHost();
 
-            //hack for functional tests
-            if (host.startsWith("localhost")) return "ft_test_pkey";
-            else return host.replaceAll("([^\\.]+)\\.(openregister)\\..*", "$1");
-
+            return host.replaceAll("([^\\.]+)\\.(openregister)\\..*", "$1");
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/uk/gov/register/presentation/resource/ResourceBase.java
+++ b/src/main/java/uk/gov/register/presentation/resource/ResourceBase.java
@@ -15,7 +15,11 @@ public abstract class ResourceBase {
         try {
             String host = new URI(httpServletRequest.getRequestURL().toString()).getHost();
 
-            return host.replaceAll("([^\\.]+)\\.(openregister)\\..*", "$1");
+            if (host.contains(".")) {
+                return host.substring(0, host.indexOf("."));
+            } else {
+                return host;
+            }
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/uk/gov/register/presentation/functional/CsvRepresentationTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/CsvRepresentationTest.java
@@ -13,9 +13,9 @@ public class CsvRepresentationTest extends FunctionalTestBase{
     @BeforeClass
     public static void publishTestMessages() {
         publishMessagesToDB(ImmutableList.of(
-                "{\"hash\":\"hash1\",\"entry\":{\"name\":\"ellis\",\"ft_test_pkey\":\"123,45\"}}",
-                "{\"hash\":\"hash2\",\"entry\":{\"name\":\"presley\",\"ft_test_pkey\":\"6789\"}}",
-                "{\"hash\":\"hash3\",\"entry\":{\"name\":\"ellis\",\"ft_test_pkey\":\"145678\"}}"
+                "{\"hash\":\"hash1\",\"entry\":{\"name\":\"ellis\",\"ft-test-pkey\":\"123,45\"}}",
+                "{\"hash\":\"hash2\",\"entry\":{\"name\":\"presley\",\"ft-test-pkey\":\"6789\"}}",
+                "{\"hash\":\"hash3\",\"entry\":{\"name\":\"ellis\",\"ft-test-pkey\":\"145678\"}}"
         ));
     }
 
@@ -24,7 +24,7 @@ public class CsvRepresentationTest extends FunctionalTestBase{
         Response response = getRequest("/all.csv");
 
         assertThat(response.getHeaderString("Content-Type"), equalTo("text/csv;charset=utf-8"));
-        assertThat(response.readEntity(String.class), equalTo("hash,name,ft_test_pkey\r\nhash2,presley,6789\r\nhash3,ellis,145678\r\nhash1,ellis,\"123,45\"\r\n"));
+        assertThat(response.readEntity(String.class), equalTo("hash,name,ft-test-pkey\r\nhash2,presley,6789\r\nhash3,ellis,145678\r\nhash1,ellis,\"123,45\"\r\n"));
     }
 
     @Test
@@ -32,6 +32,6 @@ public class CsvRepresentationTest extends FunctionalTestBase{
         Response response = getRequest("/all.tsv");
 
         assertThat(response.getHeaderString("Content-Type"), equalTo("text/tab-separated-values;charset=utf-8"));
-        assertThat(response.readEntity(String.class), equalTo("hash\tname\tft_test_pkey\nhash2\tpresley\t6789\nhash3\tellis\t145678\nhash1\tellis\t123,45\n"));
+        assertThat(response.readEntity(String.class), equalTo("hash\tname\tft-test-pkey\nhash2\tpresley\t6789\nhash3\tellis\t145678\nhash1\tellis\t123,45\n"));
     }
 }

--- a/src/test/java/uk/gov/register/presentation/functional/FindEntityTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/FindEntityTest.java
@@ -21,18 +21,18 @@ public class FindEntityTest extends FunctionalTestBase {
     @BeforeClass
     public static void publishTestMessages() {
         publishMessagesToDB(ImmutableList.of(
-                "{\"hash\":\"hash1\",\"entry\":{\"name\":\"ellis\",\"ft_test_pkey\":\"12345\"}}",
-                "{\"hash\":\"hash2\",\"entry\":{\"name\":\"presley\",\"ft_test_pkey\":\"6789\"}}",
-                "{\"hash\":\"hash3\",\"entry\":{\"name\":\"ellis\",\"ft_test_pkey\":\"145678\"}}"
+                "{\"hash\":\"hash1\",\"entry\":{\"name\":\"ellis\",\"ft-test-pkey\":\"12345\"}}",
+                "{\"hash\":\"hash2\",\"entry\":{\"name\":\"presley\",\"ft-test-pkey\":\"6789\"}}",
+                "{\"hash\":\"hash3\",\"entry\":{\"name\":\"ellis\",\"ft-test-pkey\":\"145678\"}}"
         ));
         OBJECT_MAPPER = Jackson.newObjectMapper();
     }
 
     @Test
     public void findByPrimaryKey_shouldReturnEntryWithThPrimaryKey() {
-        Response response = getRequest("/ft_test_pkey/12345.json");
+        Response response = getRequest("/ft-test-pkey/12345.json");
 
-        assertThat(response.readEntity(String.class), equalTo("{\"hash\":\"hash1\",\"entry\":{\"name\":\"ellis\",\"ft_test_pkey\":\"12345\"}}"));
+        assertThat(response.readEntity(String.class), equalTo("{\"hash\":\"hash1\",\"entry\":{\"name\":\"ellis\",\"ft-test-pkey\":\"12345\"}}"));
     }
 
     @Test
@@ -48,7 +48,7 @@ public class FindEntityTest extends FunctionalTestBase {
         Response response = getRequest("/hash/hash2.json");
 
         assertThat(OBJECT_MAPPER.readValue(response.readEntity(String.class), JsonNode.class),
-                equalTo(OBJECT_MAPPER.readValue("{\"hash\":\"hash2\",\"entry\":{\"name\":\"presley\",\"ft_test_pkey\":\"6789\"}}", JsonNode.class)));
+                equalTo(OBJECT_MAPPER.readValue("{\"hash\":\"hash2\",\"entry\":{\"name\":\"presley\",\"ft-test-pkey\":\"6789\"}}", JsonNode.class)));
     }
 
     @Test
@@ -57,7 +57,7 @@ public class FindEntityTest extends FunctionalTestBase {
 
         String jsonResponse = response.readEntity(String.class);
         assertThat(OBJECT_MAPPER.readValue(jsonResponse, JsonNode.class),
-                equalTo(OBJECT_MAPPER.readValue("[{\"hash\":\"hash2\",\"entry\":{\"name\":\"presley\",\"ft_test_pkey\":\"6789\"}},{\"hash\":\"hash3\",\"entry\":{\"name\":\"ellis\",\"ft_test_pkey\":\"145678\"}},{\"hash\":\"hash1\",\"entry\":{\"name\":\"ellis\",\"ft_test_pkey\":\"12345\"}}]", JsonNode.class)));
+                equalTo(OBJECT_MAPPER.readValue("[{\"hash\":\"hash2\",\"entry\":{\"name\":\"presley\",\"ft-test-pkey\":\"6789\"}},{\"hash\":\"hash3\",\"entry\":{\"name\":\"ellis\",\"ft-test-pkey\":\"145678\"}},{\"hash\":\"hash1\",\"entry\":{\"name\":\"ellis\",\"ft-test-pkey\":\"12345\"}}]", JsonNode.class)));
     }
 
     @Test
@@ -65,7 +65,7 @@ public class FindEntityTest extends FunctionalTestBase {
         Response response = getRequest("/search.json?name=ellis");
 
         assertThat(response.readEntity(String.class), equalTo(
-                "[{\"hash\":\"hash3\",\"entry\":{\"name\":\"ellis\",\"ft_test_pkey\":\"145678\"}},{\"hash\":\"hash1\",\"entry\":{\"name\":\"ellis\",\"ft_test_pkey\":\"12345\"}}]"
+                "[{\"hash\":\"hash3\",\"entry\":{\"name\":\"ellis\",\"ft-test-pkey\":\"145678\"}},{\"hash\":\"hash1\",\"entry\":{\"name\":\"ellis\",\"ft-test-pkey\":\"12345\"}}]"
         ));
     }
 
@@ -74,7 +74,7 @@ public class FindEntityTest extends FunctionalTestBase {
         Response response = getRequest("/search.json");
 
         assertThat(response.readEntity(String.class), equalTo(
-                "[{\"hash\":\"hash2\",\"entry\":{\"name\":\"presley\",\"ft_test_pkey\":\"6789\"}},{\"hash\":\"hash3\",\"entry\":{\"name\":\"ellis\",\"ft_test_pkey\":\"145678\"}},{\"hash\":\"hash1\",\"entry\":{\"name\":\"ellis\",\"ft_test_pkey\":\"12345\"}}]"
+                "[{\"hash\":\"hash2\",\"entry\":{\"name\":\"presley\",\"ft-test-pkey\":\"6789\"}},{\"hash\":\"hash3\",\"entry\":{\"name\":\"ellis\",\"ft-test-pkey\":\"145678\"}},{\"hash\":\"hash1\",\"entry\":{\"name\":\"ellis\",\"ft-test-pkey\":\"12345\"}}]"
         ));
     }
 

--- a/src/test/java/uk/gov/register/presentation/functional/FunctionalTestBase.java
+++ b/src/test/java/uk/gov/register/presentation/functional/FunctionalTestBase.java
@@ -30,7 +30,7 @@ public class FunctionalTestBase {
     }
 
     Response getRequest(String path) {
-        return client.target(String.format("http://localhost:%d%s", APPLICATION_PORT, path)).request().header("Host","ft-test-pkey.openregister.org").get();
+        return client.target(String.format("http://localhost:%d%s", APPLICATION_PORT, path)).request().header("Host","ft-test-pkey.beta.openregister.org").get();
     }
 
 

--- a/src/test/java/uk/gov/register/presentation/functional/FunctionalTestBase.java
+++ b/src/test/java/uk/gov/register/presentation/functional/FunctionalTestBase.java
@@ -30,7 +30,7 @@ public class FunctionalTestBase {
     }
 
     Response getRequest(String path) {
-        return client.target(String.format("http://localhost:%d%s", APPLICATION_PORT, path)).request().get();
+        return client.target(String.format("http://localhost:%d%s", APPLICATION_PORT, path)).request().header("Host","ft-test-pkey.openregister.org").get();
     }
 
 

--- a/src/test/java/uk/gov/register/presentation/functional/TurtleRepresentationTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/TurtleRepresentationTest.java
@@ -13,15 +13,15 @@ public class TurtleRepresentationTest extends FunctionalTestBase {
     @BeforeClass
     public static void publishTestMessages() {
         publishMessagesToDB(ImmutableList.of(
-                "{\"hash\":\"someHash1\",\"entry\":{\"name\":\"The Entry 1\", \"key1\":\"value1\", \"ft_test_pkey\":\"12345\"}}",
-                "{\"hash\":\"someHash2\",\"entry\":{\"name\":\"The Entry 2\", \"key1\":\"value2\", \"ft_test_pkey\":\"67890\"}}"
+                "{\"hash\":\"someHash1\",\"entry\":{\"name\":\"The Entry 1\", \"key1\":\"value1\", \"ft-test-pkey\":\"12345\"}}",
+                "{\"hash\":\"someHash2\",\"entry\":{\"name\":\"The Entry 2\", \"key1\":\"value2\", \"ft-test-pkey\":\"67890\"}}"
         ));
     }
 
     public static final String EXPECTED_SINGLE_RECORD = "<http://localhost:9000/hash/someHash1>;\n" +
             " key1 \"value1\" ;\n" +
             " name \"The Entry 1\" ;\n" +
-            " ft_test_pkey \"12345\" .\n";
+            " ft-test-pkey \"12345\" .\n";
 
 
     public static final String TEXT_TURTLE = "text/turtle;charset=utf-8";
@@ -38,7 +38,7 @@ public class TurtleRepresentationTest extends FunctionalTestBase {
             "<http://localhost:9000/hash/someHash2>;\n" +
                     " key1 \"value2\" ;\n" +
                     " name \"The Entry 2\" ;\n" +
-                    " ft_test_pkey \"67890\" .\n"
+                    " ft-test-pkey \"67890\" .\n"
                     + EXPECTED_SINGLE_RECORD;
 
     @Test

--- a/src/test/java/uk/gov/register/presentation/resource/ResourceBaseTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/ResourceBaseTest.java
@@ -1,0 +1,38 @@
+package uk.gov.register.presentation.resource;
+
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ResourceBaseTest {
+    @Test
+    public void takesRegisterNameFromHttpHost() throws Exception {
+        ResourceBase resourceBase = new TestResourceBase("http://school.beta.openregister.org:8080/school/1234.json", "school.beta.openregister.org");
+
+        String registerPrimaryKey = resourceBase.getRegisterPrimaryKey();
+
+        assertThat(registerPrimaryKey, equalTo("school"));
+    }
+
+    @Test
+    public void behavesGracefullyWhenGivenHostWithNoDots() throws Exception {
+        ResourceBase resourceBase = new TestResourceBase("http://school:8080/school/1234.json", "school");
+
+        String registerPrimaryKey = resourceBase.getRegisterPrimaryKey();
+
+        assertThat(registerPrimaryKey, equalTo("school"));
+    }
+
+    public class TestResourceBase extends ResourceBase {
+        public TestResourceBase(String requestUrl, String hostHeader) {
+            this.httpServletRequest = mock(HttpServletRequest.class);
+            when(httpServletRequest.getRequestURL()).thenReturn(new StringBuffer(requestUrl));
+            when(httpServletRequest.getHeader("Host")).thenReturn(hostHeader);
+        }
+    }
+}

--- a/src/test/java/uk/gov/register/presentation/resource/ResourceBaseTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/ResourceBaseTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.when;
 public class ResourceBaseTest {
     @Test
     public void takesRegisterNameFromHttpHost() throws Exception {
-        ResourceBase resourceBase = new TestResourceBase("http://school.beta.openregister.org:8080/school/1234.json", "school.beta.openregister.org");
+        ResourceBase resourceBase = new TestResourceBase("school.beta.openregister.org");
 
         String registerPrimaryKey = resourceBase.getRegisterPrimaryKey();
 
@@ -21,7 +21,7 @@ public class ResourceBaseTest {
 
     @Test
     public void behavesGracefullyWhenGivenHostWithNoDots() throws Exception {
-        ResourceBase resourceBase = new TestResourceBase("http://school:8080/school/1234.json", "school");
+        ResourceBase resourceBase = new TestResourceBase("school");
 
         String registerPrimaryKey = resourceBase.getRegisterPrimaryKey();
 
@@ -29,9 +29,8 @@ public class ResourceBaseTest {
     }
 
     public class TestResourceBase extends ResourceBase {
-        public TestResourceBase(String requestUrl, String hostHeader) {
+        public TestResourceBase(String hostHeader) {
             this.httpServletRequest = mock(HttpServletRequest.class);
-            when(httpServletRequest.getRequestURL()).thenReturn(new StringBuffer(requestUrl));
             when(httpServletRequest.getHeader("Host")).thenReturn(hostHeader);
         }
     }

--- a/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
@@ -36,7 +36,7 @@ public class SearchResourceTest {
         SearchResource resource = new SearchResource(queryDAO);
         resource.httpServletRequest = httpServletRequest;
 
-        when(httpServletRequest.getRequestURL()).thenReturn(new StringBuffer("http://localhost:9999/someOtherKey/value"));
+        when(httpServletRequest.getHeader("Host")).thenReturn("localhost");
         try {
             resource.findByPrimaryKey("someOtherKey", "value");
             fail("Must fail");
@@ -50,7 +50,7 @@ public class SearchResourceTest {
         SearchResource resource = new SearchResource(queryDAO);
         resource.httpServletRequest = httpServletRequest;
 
-        when(httpServletRequest.getRequestURL()).thenReturn(new StringBuffer("http://school.openregister.org/school/value"));
+        when(httpServletRequest.getHeader("Host")).thenReturn("school.openregister.org");
         when(queryDAO.findByKeyValue("school", "value")).thenReturn(Optional.<Entry>absent());
         try {
             resource.findByPrimaryKey("school", "value");
@@ -66,7 +66,7 @@ public class SearchResourceTest {
         SearchResource resource = new SearchResource(queryDAO);
         resource.httpServletRequest = httpServletRequest;
 
-        when(httpServletRequest.getRequestURL()).thenReturn(new StringBuffer("http://school.openregister.org/hash/123"));
+        when(httpServletRequest.getHeader("Host")).thenReturn("school.openregister.org");
         when(queryDAO.findByHash("123")).thenReturn(Optional.<Entry>absent());
         try {
             resource.findByHash("123");


### PR DESCRIPTION
Previously, a host of school.beta.openregister.org would cause the
register to think the primary key was `school.beta`.  After this commit,
it thinks it is `school`.
