### PR TITLE
Using prefix 'field' for all fields in turtle representation.

### DIFF
--- a/src/main/java/uk/gov/register/presentation/representations/TurtleWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/TurtleWriter.java
@@ -56,7 +56,7 @@ public class TurtleWriter extends RepresentationWriter<View> {
 
     private String renderRecord(Entry node, List<String> fields) {
         URI hashUri = uri(node.getHash());
-        String entity = String.format("<%s>;\n", hashUri);
+        String entity = String.format("<%s>\n", hashUri);
         return fields.stream()
                 .map(field -> String.format(" field:%s %s", field, node.getContent().get(field)))
                 .collect(Collectors.joining(" ;\n", entity, " ."));

--- a/src/main/java/uk/gov/register/presentation/representations/TurtleWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/TurtleWriter.java
@@ -25,6 +25,8 @@ import java.util.stream.Collectors;
 
 @Produces(ExtraMediaType.TEXT_TTL)
 public class TurtleWriter extends RepresentationWriter<View> {
+    private static final String PREFIX ="@prefix field: <http://field.openregister.org/field/>.\n\n";
+
     @Override
     public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
         return SingleResultView.class.isAssignableFrom(type) || ListResultView.class.isAssignableFrom(type);
@@ -39,6 +41,7 @@ public class TurtleWriter extends RepresentationWriter<View> {
 
         List<String> fields = entryFields(JsonObjectMapper.convert(entries.get(0).getContent(), new TypeReference<Map<String, Object>>() {
         }));
+        entityStream.write(PREFIX.getBytes("utf-8"));
         for (Entry entry : entries) {
             entityStream.write((renderRecord(entry, fields) + "\n").getBytes("utf-8"));
         }
@@ -55,7 +58,7 @@ public class TurtleWriter extends RepresentationWriter<View> {
         URI hashUri = uri(node.getHash());
         String entity = String.format("<%s>;\n", hashUri);
         return fields.stream()
-                .map(field -> String.format(" %s %s", field, node.getContent().get(field)))
+                .map(field -> String.format(" field:%s %s", field, node.getContent().get(field)))
                 .collect(Collectors.joining(" ;\n", entity, " ."));
     }
 

--- a/src/test/java/uk/gov/register/presentation/functional/TurtleRepresentationTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/TurtleRepresentationTest.java
@@ -18,7 +18,7 @@ public class TurtleRepresentationTest extends FunctionalTestBase {
         ));
     }
 
-    public static final String EXPECTED_SINGLE_RECORD = "<http://localhost:9000/hash/someHash1>;\n" +
+    public static final String EXPECTED_SINGLE_RECORD = "<http://localhost:9000/hash/someHash1>\n" +
             " field:key1 \"value1\" ;\n" +
             " field:name \"The Entry 1\" ;\n" +
             " field:ft-test-pkey \"12345\" .\n";
@@ -38,7 +38,7 @@ public class TurtleRepresentationTest extends FunctionalTestBase {
     }
 
     public static final String EXPECTED_LIST_RECORDS =
-            "<http://localhost:9000/hash/someHash2>;\n" +
+            "<http://localhost:9000/hash/someHash2>\n" +
                     " field:key1 \"value2\" ;\n" +
                     " field:name \"The Entry 2\" ;\n" +
                     " field:ft-test-pkey \"67890\" .\n"

--- a/src/test/java/uk/gov/register/presentation/functional/TurtleRepresentationTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/TurtleRepresentationTest.java
@@ -19,9 +19,12 @@ public class TurtleRepresentationTest extends FunctionalTestBase {
     }
 
     public static final String EXPECTED_SINGLE_RECORD = "<http://localhost:9000/hash/someHash1>;\n" +
-            " key1 \"value1\" ;\n" +
-            " name \"The Entry 1\" ;\n" +
-            " ft-test-pkey \"12345\" .\n";
+            " field:key1 \"value1\" ;\n" +
+            " field:name \"The Entry 1\" ;\n" +
+            " field:ft-test-pkey \"12345\" .\n";
+
+
+    public static final String PREFIX ="@prefix field: <http://field.openregister.org/field/>.\n\n";
 
 
     public static final String TEXT_TURTLE = "text/turtle;charset=utf-8";
@@ -31,14 +34,14 @@ public class TurtleRepresentationTest extends FunctionalTestBase {
         Response response = getRequest("/hash/someHash1.ttl");
 
         assertThat(response.getHeaderString("Content-Type"), equalTo(TEXT_TURTLE));
-        assertThat(response.readEntity(String.class), equalTo(EXPECTED_SINGLE_RECORD));
+        assertThat(response.readEntity(String.class), equalTo(PREFIX + EXPECTED_SINGLE_RECORD));
     }
 
     public static final String EXPECTED_LIST_RECORDS =
             "<http://localhost:9000/hash/someHash2>;\n" +
-                    " key1 \"value2\" ;\n" +
-                    " name \"The Entry 2\" ;\n" +
-                    " ft-test-pkey \"67890\" .\n"
+                    " field:key1 \"value2\" ;\n" +
+                    " field:name \"The Entry 2\" ;\n" +
+                    " field:ft-test-pkey \"67890\" .\n"
                     + EXPECTED_SINGLE_RECORD;
 
     @Test
@@ -46,6 +49,6 @@ public class TurtleRepresentationTest extends FunctionalTestBase {
         Response response = getRequest("/all.ttl");
 
         assertThat(response.getHeaderString("Content-Type"), equalTo(TEXT_TURTLE));
-        assertThat(response.readEntity(String.class), equalTo(EXPECTED_LIST_RECORDS));
+        assertThat(response.readEntity(String.class), equalTo(PREFIX + EXPECTED_LIST_RECORDS));
     }
 }


### PR DESCRIPTION
Using prefix 'field' for all fields in turtle representation.
