### PR TITLE
Removed hardcoded register base url from turtle representation.

### DIFF
--- a/src/main/java/uk/gov/register/presentation/representations/TurtleWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/TurtleWriter.java
@@ -4,8 +4,10 @@ import io.dropwizard.views.View;
 import uk.gov.register.presentation.Record;
 import uk.gov.register.presentation.resource.ResourceBase;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriBuilder;
@@ -14,12 +16,17 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.net.URI;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Produces(ExtraMediaType.TEXT_TTL)
 public class TurtleWriter extends RepresentationWriter<View> {
-    private static final String PREFIX ="@prefix field: <http://field.openregister.org/field/>.\n\n";
+    private static final String PREFIX = "@prefix field: <http://field.openregister.org/field/>.\n\n";
+
+    @Context
+    private HttpServletRequest httpServletRequest;
 
     @Override
     public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
@@ -40,9 +47,6 @@ public class TurtleWriter extends RepresentationWriter<View> {
         }
     }
 
-    //TODO: this should be retrieved from register call
-    private static final String registerBaseUri = "http://localhost:9000";
-
     private String renderRecord(Record record, Set<String> fields) {
         URI hashUri = uri(record.getHash());
         String entity = String.format("<%s>\n", hashUri);
@@ -52,6 +56,7 @@ public class TurtleWriter extends RepresentationWriter<View> {
     }
 
     private URI uri(String hash) {
-        return UriBuilder.fromPath(registerBaseUri + "/hash/" + hash).build();
+        return UriBuilder.fromUri(httpServletRequest.getRequestURL().toString()).replacePath(null).path("hash").path(hash).build();
+
     }
 }

--- a/src/test/java/uk/gov/register/presentation/functional/TurtleRepresentationTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/TurtleRepresentationTest.java
@@ -18,7 +18,7 @@ public class TurtleRepresentationTest extends FunctionalTestBase {
         ));
     }
 
-    public static final String EXPECTED_SINGLE_RECORD = "<http://localhost:9000/hash/someHash1>\n" +
+    public static final String EXPECTED_SINGLE_RECORD = "<http://ft-test-pkey.beta.openregister.org/hash/someHash1>\n" +
             " field:key1 \"value1\" ;\n" +
             " field:name \"The Entry 1\" ;\n" +
             " field:ft-test-pkey \"12345\" .\n";
@@ -38,7 +38,7 @@ public class TurtleRepresentationTest extends FunctionalTestBase {
     }
 
     public static final String EXPECTED_LIST_RECORDS =
-            "<http://localhost:9000/hash/someHash2>\n" +
+            "<http://ft-test-pkey.beta.openregister.org/hash/someHash2>\n" +
                     " field:key1 \"value2\" ;\n" +
                     " field:name \"The Entry 2\" ;\n" +
                     " field:ft-test-pkey \"67890\" .\n"


### PR DESCRIPTION
Removed hardcoded register base url from turtle representation.
Small refactoring to make sure that TurtleWriter extends specific generic type of RepresentationWriter which is ThymeleafView.
