### PR TITLE
Support csv and tsv for single entry pages

### DIFF
--- a/src/main/java/uk/gov/register/presentation/representations/CsvWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/CsvWriter.java
@@ -2,31 +2,20 @@ package uk.gov.register.presentation.representations;
 
 import org.apache.commons.lang3.StringEscapeUtils;
 import uk.gov.register.presentation.Record;
-import uk.gov.register.presentation.resource.ResourceBase;
 
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 @Produces(ExtraMediaType.TEXT_CSV)
-public class CsvWriter extends RepresentationWriter<ResourceBase.ListResultView> {
+public class CsvWriter extends RepresentationWriter {
     @Override
-    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
-        return ResourceBase.ListResultView.class.isAssignableFrom(type);
-    }
-
-    @Override
-    public void writeTo(ResourceBase.ListResultView view, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
-        List<Record> records = view.getRecords();
+    protected void writeRecordsTo(OutputStream entityStream, List<Record> records) throws IOException, WebApplicationException {
         List<String> headers = getHeaders(records.get(0));
         entityStream.write((String.join(",", headers) + "\r\n").getBytes("utf-8"));
         for (Record record : records) {

--- a/src/main/java/uk/gov/register/presentation/representations/RepresentationWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/RepresentationWriter.java
@@ -1,14 +1,41 @@
 package uk.gov.register.presentation.representations;
 
+import io.dropwizard.views.View;
+import uk.gov.register.presentation.Record;
+import uk.gov.register.presentation.resource.ResourceBase;
+
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.ext.MessageBodyWriter;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
 
-public abstract class RepresentationWriter<T> implements MessageBodyWriter<T> {
+public abstract class RepresentationWriter implements MessageBodyWriter<View> {
     @Override
-    public final long getSize(T t, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    public final long getSize(View t, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
         // deprecated and ignored by Jersey 2. Returning -1 as per javadoc in the interface
         return -1;
     }
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return ResourceBase.SingleResultView.class.isAssignableFrom(type) || ResourceBase.ListResultView.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public void writeTo(View view, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
+        if (view instanceof ResourceBase.SingleResultView) {
+            writeRecordsTo(entityStream, Collections.singletonList(((ResourceBase.SingleResultView) view).getRecord()));
+        }
+        else {
+            writeRecordsTo(entityStream, ((ResourceBase.ListResultView) view).getRecords());
+        }
+    }
+
+    protected abstract void writeRecordsTo(OutputStream entityStream, List<Record> records) throws IOException, WebApplicationException;
 }

--- a/src/main/java/uk/gov/register/presentation/representations/TsvWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/TsvWriter.java
@@ -1,31 +1,20 @@
 package uk.gov.register.presentation.representations;
 
 import uk.gov.register.presentation.Record;
-import uk.gov.register.presentation.resource.ResourceBase;
 
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 @Produces(ExtraMediaType.TEXT_TSV)
-public class TsvWriter  extends RepresentationWriter<ResourceBase.ListResultView>  {
+public class TsvWriter extends RepresentationWriter {
     @Override
-    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
-        return ResourceBase.ListResultView.class.isAssignableFrom(type);
-    }
-
-    @Override
-    public void writeTo(ResourceBase.ListResultView view, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
-        List<Record> records = view.getRecords();
+    protected void writeRecordsTo(OutputStream entityStream, List<Record> records) throws IOException, WebApplicationException {
         List<String> headers = getHeaders(records.get(0));
         entityStream.write((String.join("\t", headers) + "\n").getBytes("utf-8"));
         for (Record record : records) {

--- a/src/main/java/uk/gov/register/presentation/representations/TurtleWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/TurtleWriter.java
@@ -1,45 +1,27 @@
 package uk.gov.register.presentation.representations;
 
-import io.dropwizard.views.View;
 import uk.gov.register.presentation.Record;
-import uk.gov.register.presentation.resource.ResourceBase;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Produces;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriBuilder;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Type;
 import java.net.URI;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 @Produces(ExtraMediaType.TEXT_TTL)
-public class TurtleWriter extends RepresentationWriter<View> {
+public class TurtleWriter extends RepresentationWriter {
     private static final String PREFIX = "@prefix field: <http://field.openregister.org/field/>.\n\n";
 
     @Context
     private HttpServletRequest httpServletRequest;
 
     @Override
-    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
-        return ResourceBase.SingleResultView.class.isAssignableFrom(type) || ResourceBase.ListResultView.class.isAssignableFrom(type);
-    }
-
-    @Override
-    public void writeTo(View view, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
-        List<Record> records =
-                view instanceof ResourceBase.SingleResultView ?
-                        Collections.singletonList(((ResourceBase.SingleResultView) view).getRecord()) :
-                        ((ResourceBase.ListResultView) view).getRecords();
-
+    protected void writeRecordsTo(OutputStream entityStream, List<Record> records) throws IOException {
         Set<String> fields = records.get(0).getEntry().keySet();
         entityStream.write(PREFIX.getBytes("utf-8"));
         for (Record record : records) {
@@ -57,6 +39,5 @@ public class TurtleWriter extends RepresentationWriter<View> {
 
     private URI uri(String hash) {
         return UriBuilder.fromUri(httpServletRequest.getRequestURL().toString()).replacePath(null).path("hash").path(hash).build();
-
     }
 }

--- a/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
@@ -37,7 +37,7 @@ public class SearchResource extends ResourceBase {
 
     @GET
     @Path("/{primaryKey}/{primaryKeyValue}")
-    @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_TTL})
+    @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
     public SingleResultView findByPrimaryKey(@PathParam("primaryKey") String key, @PathParam("primaryKeyValue") String value) {
         String registerPrimaryKey = getRegisterPrimaryKey();
         if (key.equals(registerPrimaryKey)) {
@@ -52,7 +52,7 @@ public class SearchResource extends ResourceBase {
 
     @GET
     @Path("/hash/{hash}")
-    @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_TTL})
+    @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
     public SingleResultView findByHash(@PathParam("hash") String hash) {
         Optional<Record> record = queryDAO.findByHash(hash);
         if (record.isPresent()) {

--- a/src/test/java/uk/gov/register/presentation/functional/CsvRepresentationTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/CsvRepresentationTest.java
@@ -28,10 +28,26 @@ public class CsvRepresentationTest extends FunctionalTestBase{
     }
 
     @Test
+    public void csvRepresentationIsSupportedForEntry() {
+        Response response = getRequest("/hash/hash1.csv");
+
+        assertThat(response.getHeaderString("Content-Type"), equalTo("text/csv;charset=utf-8"));
+        assertThat(response.readEntity(String.class), equalTo("hash,name,ft-test-pkey\r\nhash1,ellis,\"123,45\"\r\n"));
+    }
+
+    @Test
     public void tsvRepresentationIsSupportedForEntries() {
         Response response = getRequest("/all.tsv");
 
         assertThat(response.getHeaderString("Content-Type"), equalTo("text/tab-separated-values;charset=utf-8"));
         assertThat(response.readEntity(String.class), equalTo("hash\tname\tft-test-pkey\nhash2\tpresley\t6789\nhash3\tellis\t145678\nhash1\tellis\t123,45\n"));
+    }
+
+    @Test
+    public void tsvRepresentationIsSupportedForEntry() {
+        Response response = getRequest("/hash/hash1.tsv");
+
+        assertThat(response.getHeaderString("Content-Type"), equalTo("text/tab-separated-values;charset=utf-8"));
+        assertThat(response.readEntity(String.class), equalTo("hash\tname\tft-test-pkey\nhash1\tellis\t123,45\n"));
     }
 }


### PR DESCRIPTION
The template for a single entry page has links to csv and tsv
representations, but we had no support for rendering them.  We could
either remove the links, or support these representations for single
entries.  This commit adds the required support to tsv and csv.
