### PR TITLE
add robots.txt to deny everything

### DIFF
--- a/src/main/java/uk/gov/register/presentation/resource/HomePageResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/HomePageResource.java
@@ -15,4 +15,12 @@ public class HomePageResource extends ResourceBase{
     public View home() {
         return new ThymeleafView(httpServletRequest, httpServletResponse, servletContext, "home.html");
     }
+
+    @GET
+    @Path("/robots.txt")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String robots() {
+        return "User-agent: *\n" +
+                "Disallow: /\n";
+    }
 }


### PR DESCRIPTION
at this early stage, particularly while registers are not authoritative,
we don't want to appear in search results and steal traffic from
authoritative sources.
