### PR TITLE
Using postgres as default user. 

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,7 @@ server:
 database:
   driverClass: org.postgresql.Driver
   url: jdbc:postgresql://${POSTGRES_PORT_5432_TCP_ADDR:-localhost}:${POSTGRES_PORT_5432_TCP_PORT:-5432}/postgres
-  user: ${POSTGRES_ENV_POSTGRES_USER:-presentation}
+  user: ${POSTGRES_ENV_POSTGRES_USER:-postgres}
   password: ${POSTGRES_ENV_POSTGRES_PASSWORD:-}
   properties:
     charSet: UTF-8


### PR DESCRIPTION
Using postgres as default user. to run tests and also to start application server so that no conflicts.
 start server failed at stephen's machine because run application uses config.yaml which has default user as presentation.
