### PR TITLE
301 response for /latest and /all requests

### DIFF
--- a/src/main/java/uk/gov/register/presentation/config/PresentationConfiguration.java
+++ b/src/main/java/uk/gov/register/presentation/config/PresentationConfiguration.java
@@ -14,7 +14,6 @@ public class PresentationConfiguration extends Configuration {
     private DataSourceFactory database;
 
     public DataSourceFactory getDatabase() {
-        System.out.println(database.getUrl());
         return database;
     }
 }

--- a/src/main/java/uk/gov/register/presentation/resource/DataResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/DataResource.java
@@ -10,6 +10,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import java.net.URI;
 
 @Path("/")
 public class DataResource extends ResourceBase {
@@ -48,6 +50,34 @@ public class DataResource extends ResourceBase {
     @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
     public ListResultView current() {
         return new ListResultView("entries.html", queryDAO.getAllRecords(getRegisterPrimaryKey(), ENTRY_LIMIT));
+    }
+
+    @GET
+    @Path("/all")
+    public Response all() {
+        return create301Response("current");
+    }
+
+    @GET
+    @Path("/latest")
+    public Response latest() {
+        return create301Response("feed");
+    }
+
+    private Response create301Response(String locationMethod) {
+        String requestURI = httpServletRequest.getRequestURI();
+        String representation = requestURI.substring(requestURI.lastIndexOf("/")).replaceAll("[^\\.]+(.*)", "$1");
+
+        URI uri = UriBuilder
+                .fromUri(requestURI)
+                .replacePath(null)
+                .path(locationMethod + representation)
+                .build();
+
+        return Response
+                .status(Response.Status.MOVED_PERMANENTLY)
+                .location(uri)
+                .build();
     }
 
 }

--- a/src/main/java/uk/gov/register/presentation/resource/DataResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/DataResource.java
@@ -46,7 +46,7 @@ public class DataResource extends ResourceBase {
     @GET
     @Path("/current")
     @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
-    public ListResultView all() {
+    public ListResultView current() {
         return new ListResultView("entries.html", queryDAO.getAllRecords(getRegisterPrimaryKey(), ENTRY_LIMIT));
     }
 

--- a/src/test/java/uk/gov/register/presentation/functional/FindEntityTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/FindEntityTest.java
@@ -52,6 +52,24 @@ public class FindEntityTest extends FunctionalTestBase {
     }
 
     @Test
+    public void all_movedPermanentlyToCurrentSoReturns301() throws InterruptedException, IOException {
+        Response response = getRequest("/all.json");
+
+        assertThat(response.getStatus(), equalTo(301));
+        assertThat(response.getHeaderString("Location"), equalTo("http://ft-test-pkey.beta.openregister.org/current.json"));
+
+    }
+
+    @Test
+    public void latest_movedPermanentlyToCurrentSoReturns301() throws InterruptedException, IOException {
+        Response response = getRequest("/latest.json");
+
+        assertThat(response.getStatus(), equalTo(301));
+        assertThat(response.getHeaderString("Location"), equalTo("http://ft-test-pkey.beta.openregister.org/feed.json"));
+
+    }
+
+    @Test
     public void current_shouldReturnAllCurrentVersionsOnly() throws InterruptedException, IOException {
         Response response = getRequest("/current.json");
 

--- a/src/test/java/uk/gov/register/presentation/functional/FunctionalTestBase.java
+++ b/src/test/java/uk/gov/register/presentation/functional/FunctionalTestBase.java
@@ -27,7 +27,7 @@ public class FunctionalTestBase {
     public static void beforeClass() throws InterruptedException {
         System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
 
-        client = new JerseyClientBuilder().build();
+        client = new JerseyClientBuilder().property("jersey.config.client.followRedirects", false).build();
     }
 
     Response getRequest(String path) {

--- a/src/test/java/uk/gov/register/presentation/resource/DataResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/DataResourceTest.java
@@ -26,8 +26,8 @@ public class DataResourceTest {
     }
 
     @Test
-    public void allSupportsJsonCsvTsvHtmlAndTurtle() throws Exception {
-        Method allMethod = DataResource.class.getDeclaredMethod("all");
+    public void currentSupportsJsonCsvTsvHtmlAndTurtle() throws Exception {
+        Method allMethod = DataResource.class.getDeclaredMethod("current");
         List<String> declaredMediaTypes = asList(allMethod.getAnnotation(Produces.class).value());
         assertThat(declaredMediaTypes, hasItems(
                 MediaType.APPLICATION_JSON,

--- a/src/test/java/uk/gov/register/presentation/resource/DataResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/DataResourceTest.java
@@ -1,18 +1,28 @@
 package uk.gov.register.presentation.resource;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.register.presentation.representations.ExtraMediaType;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.lang.reflect.Method;
 import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class DataResourceTest {
+    @Mock
+    HttpServletRequest mockHttpServletRequest;
     @Test
     public void feedSupportsJsonCsvTsv() throws Exception {
         Method feedMethod = DataResource.class.getDeclaredMethod("feed");
@@ -36,5 +46,53 @@ public class DataResourceTest {
                 ExtraMediaType.TEXT_TSV,
                 ExtraMediaType.TEXT_TTL
         ));
+    }
+
+    @Test
+    public void allWithRepresentation_permanentlyRedirectsToCurrentWithSameRepresentation() {
+        DataResource dataResource = new DataResource(null);
+        dataResource.httpServletRequest = mockHttpServletRequest;
+        when(mockHttpServletRequest.getRequestURI()).thenReturn("http://abc/all.json");
+
+        Response response = dataResource.all();
+
+        assertThat(response.getStatus(), equalTo(301));
+        assertThat(response.getHeaderString("Location"), equalTo("http://abc/current.json"));
+    }
+
+    @Test
+    public void allWithoutRepresentation_permanentlyRedirectsToCurrentWithoputRepresentation() {
+        DataResource dataResource = new DataResource(null);
+        dataResource.httpServletRequest = mockHttpServletRequest;
+        when(mockHttpServletRequest.getRequestURI()).thenReturn("http://abc/all");
+
+        Response response = dataResource.all();
+
+        assertThat(response.getStatus(), equalTo(301));
+        assertThat(response.getHeaderString("Location"), equalTo("http://abc/current"));
+    }
+
+    @Test
+    public void latestWithRepresentation_permanentlyRedirectsToFeedWithSameRepresentation() {
+        DataResource dataResource = new DataResource(null);
+        dataResource.httpServletRequest = mockHttpServletRequest;
+        when(mockHttpServletRequest.getRequestURI()).thenReturn("http://abc/latest.json");
+
+        Response response = dataResource.latest();
+
+        assertThat(response.getStatus(), equalTo(301));
+        assertThat(response.getHeaderString("Location"), equalTo("http://abc/feed.json"));
+    }
+
+    @Test
+    public void latestWithoutRepresentation_permanentlyRedirectsToFeedWithoputRepresentation() {
+        DataResource dataResource = new DataResource(null);
+        dataResource.httpServletRequest = mockHttpServletRequest;
+        when(mockHttpServletRequest.getRequestURI()).thenReturn("http://abc/latest");
+
+        Response response = dataResource.latest();
+
+        assertThat(response.getStatus(), equalTo(301));
+        assertThat(response.getHeaderString("Location"), equalTo("http://abc/feed"));
     }
 }


### PR DESCRIPTION
Responding with 301 for '/all' and '/latest'
    '/all' redirects to '/current'
    '/latest' redirects to '/feed'
