### PR TITLE
actually log exceptions when they are thrown

### DIFF
--- a/src/main/java/uk/gov/register/presentation/resource/ThrowableExceptionMapper.java
+++ b/src/main/java/uk/gov/register/presentation/resource/ThrowableExceptionMapper.java
@@ -1,5 +1,7 @@
 package uk.gov.register.presentation.resource;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.register.thymeleaf.ThymeleafView;
 
 import javax.ws.rs.core.HttpHeaders;
@@ -8,8 +10,12 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
 public class ThrowableExceptionMapper extends ResourceBase implements ExceptionMapper<Throwable> {
+
+    public static final Logger LOGGER = LoggerFactory.getLogger(ThrowableExceptionMapper.class);
+
     @Override
     public Response toResponse(Throwable exception) {
+        LOGGER.warn("Uncaught exception: {}", exception);
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_HTML)
                 .entity(new ThymeleafView(httpServletRequest, httpServletResponse, servletContext, "500.html"))


### PR DESCRIPTION
Currently, if we 500 there's no useful way to work out what actually happened.
