### PR TITLE
add basic content-security-policy

### DIFF
--- a/src/main/java/uk/gov/register/presentation/ContentSecurityPolicyFilter.java
+++ b/src/main/java/uk/gov/register/presentation/ContentSecurityPolicyFilter.java
@@ -1,0 +1,15 @@
+package uk.gov.register.presentation;
+
+import com.google.common.net.HttpHeaders;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import java.io.IOException;
+
+public class ContentSecurityPolicyFilter implements ContainerResponseFilter {
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
+        responseContext.getHeaders().add(HttpHeaders.CONTENT_SECURITY_POLICY, "default-src 'self'");
+    }
+}

--- a/src/main/java/uk/gov/register/presentation/app/PresentationApplication.java
+++ b/src/main/java/uk/gov/register/presentation/app/PresentationApplication.java
@@ -18,6 +18,7 @@ import org.eclipse.jetty.servlets.CrossOriginFilter;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.server.ServerProperties;
 import org.skife.jdbi.v2.DBI;
+import uk.gov.register.presentation.ContentSecurityPolicyFilter;
 import uk.gov.register.presentation.config.FieldsConfiguration;
 import uk.gov.register.presentation.config.PresentationConfiguration;
 import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
@@ -96,6 +97,7 @@ public class PresentationApplication extends Application<PresentationConfigurati
         MutableServletContextHandler applicationContext = environment.getApplicationContext();
 
         setCorsPreflight(applicationContext);
+        jerseyEnvironment.register(ContentSecurityPolicyFilter.class);
     }
 
     private void setCorsPreflight(MutableServletContextHandler applicationContext) {

--- a/src/test/java/uk/gov/register/presentation/functional/ApplicationTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/ApplicationTest.java
@@ -26,10 +26,18 @@ public class ApplicationTest extends FunctionalTestBase {
         MultivaluedMap<String, Object> headers = response.getHeaders();
 
         assertThat(headers.get(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN), equalTo(ImmutableList.of(origin)));
-        assertThat(headers.get(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS), equalTo((ImmutableList.of("true"))));
+        assertThat(headers.get(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS), equalTo(ImmutableList.of("true")));
         assertNotNull(headers.get(HttpHeaders.ACCESS_CONTROL_MAX_AGE));
-        assertThat(headers.get(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS), equalTo((ImmutableList.of("OPTIONS,GET,PUT,POST,DELETE,HEAD"))));
-        assertThat(headers.get(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS), equalTo((ImmutableList.of("X-Requested-With,Content-Type,Accept,Origin"))));
+        assertThat(headers.get(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS), equalTo(ImmutableList.of("OPTIONS,GET,PUT,POST,DELETE,HEAD")));
+        assertThat(headers.get(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS), equalTo(ImmutableList.of("X-Requested-With,Content-Type,Accept,Origin")));
     }
 
+    @Test
+    public void appSupportsContentSecurityPolicy() throws Exception {
+        Response response = client.target("http://localhost:" + APPLICATION_PORT + "/feed")
+                .request()
+                .get();
+
+        assertThat(response.getHeaders().get(HttpHeaders.CONTENT_SECURITY_POLICY), equalTo(ImmutableList.of("default-src 'self'")));
+    }
 }


### PR DESCRIPTION
Adds a very basic content security policy which blocks all requests
which don't go back to the origin server.

This post by @alexmuller provides a lot more context on what
content-security-policy does:
https://gdstechnology.blog.gov.uk/2015/02/12/experimenting-with-content-security-policy-on-gov-uk/
