### PR TITLE
Name things consistently with our real-world discussions

### DIFF
--- a/src/main/java/uk/gov/register/presentation/DbEntry.java
+++ b/src/main/java/uk/gov/register/presentation/DbEntry.java
@@ -4,22 +4,22 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 
-public class DbRecord {
+public class DbEntry {
     private final String hash;
-    private final JsonNode jsonEntry;
+    private final JsonNode jsonContent;
 
     @JsonCreator
-    public DbRecord(@JsonProperty("hash") String hash, @JsonProperty("entry") JsonNode jsonEntry) {
+    public DbEntry(@JsonProperty("hash") String hash, @JsonProperty("entry") JsonNode jsonContent) {
         this.hash = hash;
-        this.jsonEntry = jsonEntry;
+        this.jsonContent = jsonContent;
     }
 
     public String getHash() {
         return hash;
     }
 
-    public JsonNode getEntry() {
-        return jsonEntry;
+    public JsonNode getContent() {
+        return jsonContent;
     }
 }
 

--- a/src/main/java/uk/gov/register/presentation/EntryConverter.java
+++ b/src/main/java/uk/gov/register/presentation/EntryConverter.java
@@ -13,20 +13,20 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 @Service
-public class RecordConverter {
+public class EntryConverter {
     private final FieldsConfiguration fieldsConfiguration;
     private final RequestContext requestContext;
 
     @Inject
-    public RecordConverter(FieldsConfiguration fieldsConfiguration, RequestContext requestContext) {
+    public EntryConverter(FieldsConfiguration fieldsConfiguration, RequestContext requestContext) {
         this.fieldsConfiguration = fieldsConfiguration;
         this.requestContext = requestContext;
     }
 
-    public RecordView convert(DbRecord dbRecord) {
-        Iterable<Map.Entry<String, JsonNode>> fields = () -> dbRecord.getEntry().fields();
+    public EntryView convert(DbEntry dbEntry) {
+        Iterable<Map.Entry<String, JsonNode>> fields = () -> dbEntry.getContent().fields();
         Stream<Map.Entry<String, JsonNode>> fieldStream = StreamSupport.stream(fields.spliterator(), false);
-        return new RecordView(dbRecord.getHash(), requestContext.getRegisterPrimaryKey(), fieldStream.collect(Collectors.toMap(Map.Entry::getKey, this::convert)));
+        return new EntryView(dbEntry.getHash(), requestContext.getRegisterPrimaryKey(), fieldStream.collect(Collectors.toMap(Map.Entry::getKey, this::convert)));
     }
 
 

--- a/src/main/java/uk/gov/register/presentation/EntryView.java
+++ b/src/main/java/uk/gov/register/presentation/EntryView.java
@@ -5,12 +5,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
 import java.util.Set;
 
-public class RecordView {
+public class EntryView {
     private final String registerName;
     private final Map<String, FieldValue> entryMap;
     private String hash;
 
-    public RecordView(String hash, String registerName, Map<String, FieldValue> entryMap) {
+    public EntryView(String hash, String registerName, Map<String, FieldValue> entryMap) {
         this.hash = hash;
         this.registerName = registerName;
         this.entryMap = entryMap;
@@ -18,7 +18,7 @@ public class RecordView {
 
 
     @JsonProperty("entry")
-    public Map<String, FieldValue> getEntry() {
+    public Map<String, FieldValue> getContent() {
         return entryMap;
     }
 

--- a/src/main/java/uk/gov/register/presentation/app/PresentationApplication.java
+++ b/src/main/java/uk/gov/register/presentation/app/PresentationApplication.java
@@ -19,7 +19,7 @@ import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.server.ServerProperties;
 import org.skife.jdbi.v2.DBI;
 import uk.gov.register.presentation.ContentSecurityPolicyFilter;
-import uk.gov.register.presentation.RecordConverter;
+import uk.gov.register.presentation.EntryConverter;
 import uk.gov.register.presentation.config.FieldsConfiguration;
 import uk.gov.register.presentation.config.PresentationConfiguration;
 import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
@@ -85,7 +85,7 @@ public class PresentationApplication extends Application<PresentationConfigurati
                 bind(FieldsConfiguration.class).to(FieldsConfiguration.class).in(Singleton.class);
                 bind(RequestContext.class).to(RequestContext.class);
                 bind(ViewFactory.class).to(ViewFactory.class).in(Singleton.class);
-                bind(RecordConverter.class).to(RecordConverter.class).in(Singleton.class);
+                bind(EntryConverter.class).to(EntryConverter.class).in(Singleton.class);
             }
         });
 

--- a/src/main/java/uk/gov/register/presentation/dao/RecentEntryIndexQueryDAO.java
+++ b/src/main/java/uk/gov/register/presentation/dao/RecentEntryIndexQueryDAO.java
@@ -4,32 +4,32 @@ import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
 import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
-import uk.gov.register.presentation.DbRecord;
-import uk.gov.register.presentation.mapper.RecordMapper;
+import uk.gov.register.presentation.DbEntry;
+import uk.gov.register.presentation.mapper.EntryMapper;
 
 import java.util.List;
 import java.util.Optional;
 
-@RegisterMapper(RecordMapper.class)
+@RegisterMapper(EntryMapper.class)
 public interface RecentEntryIndexQueryDAO {
 
     @SqlQuery("SELECT entry FROM ordered_entry_index ORDER BY id DESC LIMIT :limit")
-    List<DbRecord> getFeeds(@Bind("limit") int maxNumberToFetch);
+    List<DbEntry> getAllEntries(@Bind("limit") int maxNumberToFetch);
 
     @SqlQuery("SELECT entry FROM ordered_entry_index WHERE (entry #>> ARRAY['entry',:key]) = :value ORDER BY id DESC limit 1")
-    @SingleValueResult(DbRecord.class)
-    Optional<DbRecord> findByKeyValue(@Bind("key") String key, @Bind("value") String value);
+    @SingleValueResult(DbEntry.class)
+    Optional<DbEntry> findByKeyValue(@Bind("key") String key, @Bind("value") String value);
 
     @SqlQuery("SELECT entry FROM ordered_entry_index WHERE (entry #>> ARRAY['entry',:key]) = :value ORDER BY id DESC")
-    List<DbRecord> findAllByKeyValue(@Bind("key") String key, @Bind("value") String value);
+    List<DbEntry> findAllByKeyValue(@Bind("key") String key, @Bind("value") String value);
 
     @SqlQuery("SELECT entry FROM ordered_entry_index WHERE (entry #>> ARRAY['hash']) = :hash")
-    @SingleValueResult(DbRecord.class)
-    Optional<DbRecord> findByHash(@Bind("hash") String hash);
+    @SingleValueResult(DbEntry.class)
+    Optional<DbEntry> findByHash(@Bind("hash") String hash);
 
     @SqlQuery("SELECT entry FROM ordered_entry_index WHERE id = :serial")
-    @SingleValueResult(DbRecord.class)
-    Optional<DbRecord> findBySerial(@Bind("serial") int serial);
+    @SingleValueResult(DbEntry.class)
+    Optional<DbEntry> findBySerial(@Bind("serial") int serial);
 
     @SqlQuery("SELECT i.id, i.entry FROM ordered_entry_index i, ( " +
             "SELECT MAX(id) AS id " +
@@ -37,6 +37,6 @@ public interface RecentEntryIndexQueryDAO {
             "GROUP BY (entry #>> ARRAY['entry',:key])) AS ii " +
             "WHERE i.id = ii.id " +
             "ORDER BY (entry #>> ARRAY['entry',:key]) DESC LIMIT :limit")
-    List<DbRecord> getAllRecords(@Bind("key") String name,
-                                 @Bind("limit") int maxNumberToFetch);
+    List<DbEntry> getLatestEntriesOfAllRecords(@Bind("key") String name,
+                                               @Bind("limit") int maxNumberToFetch);
 }

--- a/src/main/java/uk/gov/register/presentation/mapper/EntryMapper.java
+++ b/src/main/java/uk/gov/register/presentation/mapper/EntryMapper.java
@@ -5,23 +5,23 @@ import com.google.common.base.Throwables;
 import io.dropwizard.jackson.Jackson;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
-import uk.gov.register.presentation.DbRecord;
+import uk.gov.register.presentation.DbEntry;
 
 import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-public class RecordMapper implements ResultSetMapper<DbRecord> {
+public class EntryMapper implements ResultSetMapper<DbEntry> {
     private final ObjectMapper objectMapper;
 
-    public RecordMapper() {
+    public EntryMapper() {
         objectMapper = Jackson.newObjectMapper();
     }
 
     @Override
-    public DbRecord map(int index, ResultSet r, StatementContext ctx) throws SQLException {
+    public DbEntry map(int index, ResultSet r, StatementContext ctx) throws SQLException {
         try {
-            return objectMapper.readValue(r.getBytes("entry"), DbRecord.class);
+            return objectMapper.readValue(r.getBytes("entry"), DbEntry.class);
         } catch (IOException e) {
             throw Throwables.propagate(e);
         }

--- a/src/main/java/uk/gov/register/presentation/representations/CsvWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/CsvWriter.java
@@ -1,7 +1,7 @@
 package uk.gov.register.presentation.representations;
 
 import org.apache.commons.lang3.StringEscapeUtils;
-import uk.gov.register.presentation.RecordView;
+import uk.gov.register.presentation.EntryView;
 
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
@@ -15,16 +15,16 @@ import static com.google.common.collect.Lists.newArrayList;
 @Produces(ExtraMediaType.TEXT_CSV)
 public class CsvWriter extends RepresentationWriter {
     @Override
-    protected void writeRecordsTo(OutputStream entityStream, List<RecordView> records) throws IOException, WebApplicationException {
-        List<String> fields = newArrayList(records.get(0).allFields());
+    protected void writeEntriesTo(OutputStream entityStream, List<EntryView> entries) throws IOException, WebApplicationException {
+        List<String> fields = newArrayList(entries.get(0).allFields());
         entityStream.write(("hash," + String.join(",", fields) + "\r\n").getBytes("utf-8"));
-        for (RecordView record : records) {
-            writeRow(entityStream, fields, record);
+        for (EntryView entry : entries) {
+            writeRow(entityStream, fields, entry);
         }
     }
 
-    private void writeRow(OutputStream entityStream, List<String> fields, RecordView record) throws IOException {
-        String row = fields.stream().map(field -> escape(record.getField(field).value())).collect(Collectors.joining(",", record.getHash() + ",", "\r\n"));
+    private void writeRow(OutputStream entityStream, List<String> fields, EntryView entry) throws IOException {
+        String row = fields.stream().map(field -> escape(entry.getField(field).value())).collect(Collectors.joining(",", entry.getHash() + ",", "\r\n"));
         entityStream.write(row.getBytes("utf-8"));
     }
 

--- a/src/main/java/uk/gov/register/presentation/representations/ListResultJsonSerializer.java
+++ b/src/main/java/uk/gov/register/presentation/representations/ListResultJsonSerializer.java
@@ -3,7 +3,7 @@ package uk.gov.register.presentation.representations;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import uk.gov.register.presentation.RecordView;
+import uk.gov.register.presentation.EntryView;
 import uk.gov.register.presentation.view.ListResultView;
 
 import java.io.IOException;
@@ -12,8 +12,8 @@ import java.util.List;
 public class ListResultJsonSerializer extends JsonSerializer<ListResultView> {
     @Override
     public void serialize(ListResultView value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-        List<RecordView> records = value.getRecords();
+        List<EntryView> entries = value.getEntries();
         JsonSerializer<Object> listSerializer = serializers.findValueSerializer(List.class);
-        listSerializer.serialize(records, gen, serializers);
+        listSerializer.serialize(entries, gen, serializers);
     }
 }

--- a/src/main/java/uk/gov/register/presentation/representations/RepresentationWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/RepresentationWriter.java
@@ -1,7 +1,7 @@
 package uk.gov.register.presentation.representations;
 
 import io.dropwizard.views.View;
-import uk.gov.register.presentation.RecordView;
+import uk.gov.register.presentation.EntryView;
 import uk.gov.register.presentation.view.ListResultView;
 import uk.gov.register.presentation.view.SingleResultView;
 
@@ -31,16 +31,16 @@ public abstract class RepresentationWriter implements MessageBodyWriter<View> {
     @Override
     public void writeTo(View view, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
         if (view instanceof SingleResultView) {
-            writeRecordTo(entityStream, ((SingleResultView) view).getRecord());
+            writeEntryTo(entityStream, ((SingleResultView) view).getEntry());
         }
         else {
-            writeRecordsTo(entityStream, ((ListResultView) view).getRecords());
+            writeEntriesTo(entityStream, ((ListResultView) view).getEntries());
         }
     }
 
-    protected void writeRecordTo(OutputStream entityStream, RecordView record) throws IOException {
-        writeRecordsTo(entityStream, Collections.singletonList(record));
+    protected void writeEntryTo(OutputStream entityStream, EntryView entry) throws IOException {
+        writeEntriesTo(entityStream, Collections.singletonList(entry));
     }
 
-    protected abstract void writeRecordsTo(OutputStream entityStream, List<RecordView> records) throws IOException, WebApplicationException;
+    protected abstract void writeEntriesTo(OutputStream entityStream, List<EntryView> entries) throws IOException, WebApplicationException;
 }

--- a/src/main/java/uk/gov/register/presentation/representations/SingleResultJsonSerializer.java
+++ b/src/main/java/uk/gov/register/presentation/representations/SingleResultJsonSerializer.java
@@ -3,7 +3,7 @@ package uk.gov.register.presentation.representations;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import uk.gov.register.presentation.RecordView;
+import uk.gov.register.presentation.EntryView;
 import uk.gov.register.presentation.view.SingleResultView;
 
 import java.io.IOException;
@@ -11,8 +11,8 @@ import java.io.IOException;
 public class SingleResultJsonSerializer extends JsonSerializer<SingleResultView> {
     @Override
     public void serialize(SingleResultView value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-        RecordView record = value.getRecord();
-        JsonSerializer<Object> listSerializer = serializers.findValueSerializer(RecordView.class);
-        listSerializer.serialize(record, gen, serializers);
+        EntryView entry = value.getEntry();
+        JsonSerializer<Object> listSerializer = serializers.findValueSerializer(EntryView.class);
+        listSerializer.serialize(entry, gen, serializers);
     }
 }

--- a/src/main/java/uk/gov/register/presentation/representations/TsvWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/TsvWriter.java
@@ -1,6 +1,6 @@
 package uk.gov.register.presentation.representations;
 
-import uk.gov.register.presentation.RecordView;
+import uk.gov.register.presentation.EntryView;
 
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
@@ -14,16 +14,16 @@ import static com.google.common.collect.Lists.newArrayList;
 @Produces(ExtraMediaType.TEXT_TSV)
 public class TsvWriter extends RepresentationWriter {
     @Override
-    protected void writeRecordsTo(OutputStream entityStream, List<RecordView> records) throws IOException, WebApplicationException {
-        List<String> fields = newArrayList(records.get(0).allFields());
+    protected void writeEntriesTo(OutputStream entityStream, List<EntryView> entries) throws IOException, WebApplicationException {
+        List<String> fields = newArrayList(entries.get(0).allFields());
         entityStream.write(("hash\t" + String.join("\t", fields) + "\n").getBytes("utf-8"));
-        for (RecordView record : records) {
-            writeRow(entityStream, fields, record);
+        for (EntryView entry : entries) {
+            writeRow(entityStream, fields, entry);
         }
     }
 
-    private void writeRow(OutputStream entityStream, List<String> fields, RecordView record) throws IOException {
-        String row = fields.stream().map(field -> record.getField(field).value()).collect(Collectors.joining("\t", record.getHash() + "\t", "\n"));
+    private void writeRow(OutputStream entityStream, List<String> fields, EntryView entry) throws IOException {
+        String row = fields.stream().map(field -> entry.getField(field).value()).collect(Collectors.joining("\t", entry.getHash() + "\t", "\n"));
         entityStream.write(row.getBytes("utf-8"));
     }
 }

--- a/src/main/java/uk/gov/register/presentation/representations/TurtleWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/TurtleWriter.java
@@ -3,7 +3,7 @@ package uk.gov.register.presentation.representations;
 import org.jvnet.hk2.annotations.Service;
 import uk.gov.register.presentation.FieldValue;
 import uk.gov.register.presentation.LinkValue;
-import uk.gov.register.presentation.RecordView;
+import uk.gov.register.presentation.EntryView;
 import uk.gov.register.presentation.resource.RequestContext;
 
 import javax.inject.Inject;
@@ -29,24 +29,24 @@ public class TurtleWriter extends RepresentationWriter {
     }
 
     @Override
-    protected void writeRecordsTo(OutputStream entityStream, List<RecordView> records) throws IOException {
-        Set<String> fields = records.get(0).allFields();
+    protected void writeEntriesTo(OutputStream entityStream, List<EntryView> entries) throws IOException {
+        Set<String> fields = entries.get(0).allFields();
         entityStream.write(PREFIX.getBytes("utf-8"));
-        for (RecordView record : records) {
-            entityStream.write((renderRecord(record, fields) + "\n").getBytes("utf-8"));
+        for (EntryView entry : entries) {
+            entityStream.write((renderEntry(entry, fields) + "\n").getBytes("utf-8"));
         }
     }
 
-    private String renderRecord(RecordView record, Set<String> fields) {
-        URI hashUri = uri(record.getHash());
+    private String renderEntry(EntryView entry, Set<String> fields) {
+        URI hashUri = uri(entry.getHash());
         String entity = String.format("<%s>\n", hashUri);
         return fields.stream()
-                .map(field -> renderField(record, field))
+                .map(field -> renderField(entry, field))
                 .collect(Collectors.joining(" ;\n", entity, " ."));
     }
 
-    private String renderField(RecordView record, String fieldName) {
-        FieldValue value = record.getField(fieldName);
+    private String renderField(EntryView entry, String fieldName) {
+        FieldValue value = entry.getField(fieldName);
         if (value.isLink()) {
             return String.format(" field:%s <%s>", fieldName, ((LinkValue)value).link());
         } else {

--- a/src/main/java/uk/gov/register/presentation/representations/YamlWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/YamlWriter.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.dropwizard.jackson.Jackson;
 import org.jvnet.hk2.annotations.Service;
-import uk.gov.register.presentation.RecordView;
+import uk.gov.register.presentation.EntryView;
 
 import javax.inject.Inject;
 import javax.ws.rs.Produces;
@@ -24,12 +24,12 @@ public class YamlWriter extends RepresentationWriter {
     }
 
     @Override
-    protected void writeRecordsTo(OutputStream entityStream, List<RecordView> records) throws IOException, WebApplicationException {
-        objectMapper.writeValue(entityStream, records);
+    protected void writeEntriesTo(OutputStream entityStream, List<EntryView> entries) throws IOException, WebApplicationException {
+        objectMapper.writeValue(entityStream, entries);
     }
 
     @Override
-    protected void writeRecordTo(OutputStream entityStream, RecordView record) throws IOException {
-        objectMapper.writeValue(entityStream, record);
+    protected void writeEntryTo(OutputStream entityStream, EntryView entry) throws IOException {
+        objectMapper.writeValue(entityStream, entry);
     }
 }

--- a/src/main/java/uk/gov/register/presentation/resource/DataResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/DataResource.java
@@ -52,7 +52,7 @@ public class DataResource {
     @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
     public ListResultView feed() {
         return viewFactory.getListResultView(
-                queryDAO.getFeeds(ENTRY_LIMIT)
+                queryDAO.getAllEntries(ENTRY_LIMIT)
         );
     }
 
@@ -61,7 +61,7 @@ public class DataResource {
     @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
     public ListResultView current() {
         return viewFactory.getListResultView(
-                queryDAO.getAllRecords(requestContext.getRegisterPrimaryKey(), ENTRY_LIMIT)
+                queryDAO.getLatestEntriesOfAllRecords(requestContext.getRegisterPrimaryKey(), ENTRY_LIMIT)
         );
     }
 

--- a/src/main/java/uk/gov/register/presentation/view/ListResultView.java
+++ b/src/main/java/uk/gov/register/presentation/view/ListResultView.java
@@ -1,7 +1,7 @@
 package uk.gov.register.presentation.view;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import uk.gov.register.presentation.RecordView;
+import uk.gov.register.presentation.EntryView;
 import uk.gov.register.presentation.representations.ListResultJsonSerializer;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.register.thymeleaf.ThymeleafView;
@@ -10,14 +10,14 @@ import java.util.List;
 
 @JsonSerialize(using = ListResultJsonSerializer.class)
 public class ListResultView extends ThymeleafView {
-    private final List<RecordView> records;
+    private final List<EntryView> entries;
 
-    ListResultView(RequestContext requestContext, List<RecordView> records) {
+    ListResultView(RequestContext requestContext, List<EntryView> entries) {
         super(requestContext, "entries.html");
-        this.records = records;
+        this.entries = entries;
     }
 
-    public List<RecordView> getRecords() {
-        return records;
+    public List<EntryView> getEntries() {
+        return entries;
     }
 }

--- a/src/main/java/uk/gov/register/presentation/view/SingleResultView.java
+++ b/src/main/java/uk/gov/register/presentation/view/SingleResultView.java
@@ -1,22 +1,22 @@
 package uk.gov.register.presentation.view;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import uk.gov.register.presentation.RecordView;
+import uk.gov.register.presentation.EntryView;
 import uk.gov.register.presentation.representations.SingleResultJsonSerializer;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.register.thymeleaf.ThymeleafView;
 
 @JsonSerialize(using = SingleResultJsonSerializer.class)
 public class SingleResultView extends ThymeleafView {
-    private final RecordView recordView;
+    private final EntryView entryView;
 
-    SingleResultView(RequestContext requestContext, RecordView recordView) {
+    SingleResultView(RequestContext requestContext, EntryView entryView) {
         super(requestContext, "entry.html");
-        this.recordView = recordView;
+        this.entryView = entryView;
     }
 
-    public RecordView getRecord() {
-        return recordView;
+    public EntryView getEntry() {
+        return entryView;
     }
 }
 

--- a/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
+++ b/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
@@ -1,8 +1,8 @@
 package uk.gov.register.presentation.view;
 
 import org.jvnet.hk2.annotations.Service;
-import uk.gov.register.presentation.DbRecord;
-import uk.gov.register.presentation.RecordConverter;
+import uk.gov.register.presentation.DbEntry;
+import uk.gov.register.presentation.EntryConverter;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.register.thymeleaf.ThymeleafView;
 
@@ -13,20 +13,20 @@ import java.util.stream.Collectors;
 @Service
 public class ViewFactory {
     private final RequestContext requestContext;
-    private final RecordConverter recordConverter;
+    private final EntryConverter entryConverter;
 
     @Inject
-    public ViewFactory(RequestContext requestContext, RecordConverter recordConverter) {
+    public ViewFactory(RequestContext requestContext, EntryConverter entryConverter) {
         this.requestContext = requestContext;
-        this.recordConverter = recordConverter;
+        this.entryConverter = entryConverter;
     }
 
-    public SingleResultView getSingleResultView(DbRecord dbRecord) {
-        return new SingleResultView(requestContext, recordConverter.convert(dbRecord));
+    public SingleResultView getSingleResultView(DbEntry dbEntry) {
+        return new SingleResultView(requestContext, entryConverter.convert(dbEntry));
     }
 
-    public ListResultView getListResultView(List<DbRecord> allDbRecords) {
-        return new ListResultView(requestContext, allDbRecords.stream().map(recordConverter::convert).collect(Collectors.toList()));
+    public ListResultView getListResultView(List<DbEntry> allDbEntries) {
+        return new ListResultView(requestContext, allDbEntries.stream().map(entryConverter::convert).collect(Collectors.toList()));
     }
 
     public ThymeleafView thymeleafView(String templateName) {

--- a/src/main/resources/templates/entries.html
+++ b/src/main/resources/templates/entries.html
@@ -8,22 +8,22 @@
 <div class="row entry-row">
     <div class="large-12 columns">
 
-        <table id="entries" class="responsive" th:if="${#lists.isEmpty(records) == false}">
+        <table id="entries" class="responsive" th:if="${#lists.isEmpty(entries) == false}">
             <thead>
             <tr>
                 <td>hash</td>
-                <th:block th:each="entrySet : ${records.get(0).entry}">
-                    <td><a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(entrySet.key)}" th:text="${entrySet.key}"></a></td>
+                <th:block th:each="keyValue : ${entries.get(0).entry}">
+                    <td><a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(keyValue.key)}" th:text="${keyValue.key}"></a></td>
                 </th:block>
             </tr>
             </thead>
             <tbody>
-            <tr th:each="record : ${records}">
+            <tr th:each="entry : ${entries}">
                 <td>
-                    <a th:href="${'/hash/' + record.hash}" th:text="${record.hash}"></a>
+                    <a th:href="${'/hash/' + entry.hash}" th:text="${entry.hash}"></a>
                 </td>
-                <th:block th:each="entry : ${record.entry}">
-                    <td th:text="${entry.value.value()}"></td>
+                <th:block th:each="keyValue : ${entry.content}">
+                    <td th:text="${keyValue.value.value()}"></td>
                 </th:block>
             </tr>
             </tbody>

--- a/src/main/resources/templates/entry.html
+++ b/src/main/resources/templates/entry.html
@@ -6,17 +6,17 @@
 <header th:include="main.html::header" id="global-header"></header>
 <div class="row">
     <div class="small-12 large-8 columns">
-        <h1 class="entry-header" th:text="${record.primaryKey()}">Entry Name Header</h1>
+        <h1 class="entry-header" th:text="${entry.primaryKey()}">Entry Name Header</h1>
 
         <p class="entry-source">An entry in the <a href="/"
                                                    th:text="${@uk.gov.register.presentation.RegisterNameExtractor@capitalizedRegisterName(#httpServletRequest.getHeader('Host')) + ' register'}"></a>
         </p>
 
         <p class="entry-hash">
-            <span class="entry-hash" th:text="${'hash: ' + record.hash}"></span>
+            <span class="entry-hash" th:text="${'hash: ' + entry.hash}"></span>
             <a href="#" class="tooltips">
                 <span class="tooltips-icon">?</span>
-                <span class="tooltips-text">The hash is a unique identifier for each version of a record</span>
+                <span class="tooltips-text">The hash is a unique identifier for each version of an entry</span>
             </a>
         </p>
     </div>
@@ -26,12 +26,12 @@
     <div class="small-12 large-12 columns">
         <table id="entry-table">
             <tbody>
-            <tr th:each="entry : ${record.entry}">
-                <td ><a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(entry.key)}" th:text="${entry.key}"></a></td>
-                <td th:if="${entry.value.isLink()}">
-                    <a th:href="${entry.value.link()}" th:text="${entry.value.value()}"></a>
+            <tr th:each="keyValue : ${entry.content}">
+                <td ><a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(keyValue.key)}" th:text="${keyValue.key}"></a></td>
+                <td th:if="${keyValue.value.isLink()}">
+                    <a th:href="${keyValue.value.link()}" th:text="${keyValue.value.value()}"></a>
                 </td>
-                <td th:unless="${entry.value.isLink()}" th:text="${entry.value.value()}">
+                <td th:unless="${keyValue.value.isLink()}" th:text="${keyValue.value.value()}">
                 </td>
             </tr>
             </tbody>

--- a/src/test/java/uk/gov/register/presentation/EntryConverterTest.java
+++ b/src/test/java/uk/gov/register/presentation/EntryConverterTest.java
@@ -16,19 +16,19 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 @RunWith(MockitoJUnitRunner.class)
-public class RecordConverterTest {
+public class EntryConverterTest {
     @Mock
     private RequestContext requestContext;
 
     @Test
-    public void convert_convertsTheDbRecordToRecordView() throws IOException {
-        RecordConverter recordConverter = new RecordConverter(new FieldsConfiguration(), requestContext);
+    public void convert_convertsTheDbEntryToEntryView() throws IOException {
+        EntryConverter entryConverter = new EntryConverter(new FieldsConfiguration(), requestContext);
         ObjectMapper objectMapper = Jackson.newObjectMapper();
         JsonNode jsonNode = objectMapper.readValue("{\"registry\":\"somevalue\"}", JsonNode.class);
 
-        RecordView recordView = recordConverter.convert(new DbRecord("somehash", jsonNode));
+        EntryView entryView = entryConverter.convert(new DbEntry("somehash", jsonNode));
 
-        assertThat(((LinkValue) recordView.getField("registry")).link(), equalTo("http://public-body.openregister.org/public-body/somevalue"));
+        assertThat(((LinkValue) entryView.getField("registry")).link(), equalTo("http://public-body.openregister.org/public-body/somevalue"));
     }
 
 }

--- a/src/test/java/uk/gov/register/presentation/functional/RepresentationsTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/RepresentationsTest.java
@@ -21,8 +21,8 @@ import static org.junit.Assert.assertThat;
 public class RepresentationsTest extends FunctionalTestBase {
     private final String extension;
     private final String expectedContentType;
-    private final String expectedSingleRecord;
-    private final String expectedListRecords;
+    private final String expectedSingleEntry;
+    private final String expectedListOfEntries;
 
     @BeforeClass
     public static void publishTestMessages() {
@@ -40,11 +40,11 @@ public class RepresentationsTest extends FunctionalTestBase {
         });
     }
 
-    public RepresentationsTest(String extension, String expectedContentType, String expectedSingleRecord, String expectedListRecords) {
+    public RepresentationsTest(String extension, String expectedContentType, String expectedSingleEntry, String expectedListOfEntries) {
         this.extension = extension;
         this.expectedContentType = expectedContentType;
-        this.expectedSingleRecord = expectedSingleRecord;
-        this.expectedListRecords = expectedListRecords;
+        this.expectedSingleEntry = expectedSingleEntry;
+        this.expectedListOfEntries = expectedListOfEntries;
     }
 
     @Test
@@ -53,7 +53,7 @@ public class RepresentationsTest extends FunctionalTestBase {
 
         assertThat(response.getStatus(), equalTo(200));
         assertThat(response.getHeaderString("Content-Type"), equalTo(expectedContentType));
-        assertThat(response.readEntity(String.class), equalTo(expectedSingleRecord));
+        assertThat(response.readEntity(String.class), equalTo(expectedSingleEntry));
     }
 
     @Test
@@ -62,7 +62,7 @@ public class RepresentationsTest extends FunctionalTestBase {
 
         assertThat(response.getStatus(), equalTo(200));
         assertThat(response.getHeaderString("Content-Type"), equalTo(expectedContentType));
-        assertThat(response.readEntity(String.class), equalTo(expectedListRecords));
+        assertThat(response.readEntity(String.class), equalTo(expectedListOfEntries));
     }
 
     private static String fixture(String resourceName) {

--- a/src/test/java/uk/gov/register/presentation/representations/CsvWriterTest.java
+++ b/src/test/java/uk/gov/register/presentation/representations/CsvWriterTest.java
@@ -3,7 +3,7 @@ package uk.gov.register.presentation.representations;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import uk.gov.register.presentation.FieldValue;
-import uk.gov.register.presentation.RecordView;
+import uk.gov.register.presentation.EntryView;
 import uk.gov.register.presentation.StringValue;
 
 import java.io.IOException;
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertThat;
 
 public class CsvWriterTest {
     @Test
-    public void writeRecordsTo_writesCsvEscapedEntries() throws IOException {
+    public void writeEntriesTo_writesCsvEscapedEntries() throws IOException {
         CsvWriter csvWriter = new CsvWriter();
         Map<String, FieldValue> entryMap =
                 ImmutableMap.of(
@@ -26,11 +26,11 @@ public class CsvWriterTest {
                 );
 
 
-        RecordView record = new RecordView("hash1", "registerName", entryMap);
+        EntryView entry = new EntryView("hash1", "registerName", entryMap);
 
         TestOutputStream entityStream = new TestOutputStream();
 
-        csvWriter.writeRecordsTo(entityStream, Collections.singletonList(record));
+        csvWriter.writeEntriesTo(entityStream, Collections.singletonList(entry));
 
         assertThat(entityStream.contents, equalTo("hash,key1,key2,key3,key4\r\nhash1,valu\te1,\"val,ue2\",\"val\"\"ue3\",\"val\nue4\"\r\n"));
     }

--- a/src/test/java/uk/gov/register/presentation/representations/TsvWriterTest.java
+++ b/src/test/java/uk/gov/register/presentation/representations/TsvWriterTest.java
@@ -3,7 +3,7 @@ package uk.gov.register.presentation.representations;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import uk.gov.register.presentation.FieldValue;
-import uk.gov.register.presentation.RecordView;
+import uk.gov.register.presentation.EntryView;
 import uk.gov.register.presentation.StringValue;
 
 import java.io.IOException;
@@ -25,12 +25,12 @@ public class TsvWriterTest {
                 "key3", new StringValue("val\"ue3"),
                 "key4", new StringValue("value4")
         );
-        RecordView record = new RecordView("hash1", "registerName", entryMap);
+        EntryView entry = new EntryView("hash1", "registerName", entryMap);
 
         TestOutputStream entityStream = new TestOutputStream();
 
 
-        writer.writeRecordsTo(entityStream, Collections.singletonList(record));
+        writer.writeEntriesTo(entityStream, Collections.singletonList(entry));
 
         assertThat(entityStream.contents, equalTo("hash\tkey1\tkey2\tkey3\tkey4\nhash1\tvalue1\tvalue2\tval\"ue3\tvalue4\n"));
     }

--- a/src/test/java/uk/gov/register/presentation/representations/TurtleWriterTest.java
+++ b/src/test/java/uk/gov/register/presentation/representations/TurtleWriterTest.java
@@ -5,7 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 import uk.gov.register.presentation.FieldValue;
 import uk.gov.register.presentation.LinkValue;
-import uk.gov.register.presentation.RecordView;
+import uk.gov.register.presentation.EntryView;
 import uk.gov.register.presentation.StringValue;
 import uk.gov.register.presentation.resource.RequestContext;
 
@@ -39,11 +39,11 @@ public class TurtleWriterTest {
                         "name", new StringValue("foo")
                 );
 
-        RecordView record = new RecordView("abcd", "registerName", entryMap);
+        EntryView entry = new EntryView("abcd", "registerName", entryMap);
 
         TestOutputStream entityStream = new TestOutputStream();
 
-        turtleWriter.writeRecordsTo(entityStream, Collections.singletonList(record));
+        turtleWriter.writeEntriesTo(entityStream, Collections.singletonList(entry));
 
 
         assertThat(entityStream.contents, containsString("field:registered-address <http://address.openregister.org/address/1111111>"));

--- a/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import uk.gov.register.presentation.DbRecord;
+import uk.gov.register.presentation.DbEntry;
 import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
 import uk.gov.register.presentation.representations.ExtraMediaType;
 import uk.gov.register.presentation.view.SingleResultView;
@@ -78,7 +78,7 @@ public class SearchResourceTest {
 
     @Test
     public void findByPrimaryKey_throwsNotFoundException_whenSearchedKeyIsNotFound() {
-        when(queryDAO.findByKeyValue("school", "value")).thenReturn(Optional.<DbRecord>empty());
+        when(queryDAO.findByKeyValue("school", "value")).thenReturn(Optional.<DbEntry>empty());
         try {
             resource.findByPrimaryKey("school", "value");
             fail("Must fail");
@@ -90,7 +90,7 @@ public class SearchResourceTest {
 
     @Test
     public void findByHash_throwsNotFoundWhenHashIsNotFound() {
-        when(queryDAO.findByHash("123")).thenReturn(Optional.<DbRecord>empty());
+        when(queryDAO.findByHash("123")).thenReturn(Optional.<DbEntry>empty());
         try {
             resource.findByHash("123");
             fail("Must fail");
@@ -101,7 +101,7 @@ public class SearchResourceTest {
 
     @Test
     public void findBySerial_findsEntryFromDb() throws Exception {
-        DbRecord abcd = new DbRecord("abcd", Jackson.newObjectMapper().readTree("{\"school\":\"9001\",\"address\":\"1234\"}"));
+        DbEntry abcd = new DbEntry("abcd", Jackson.newObjectMapper().readTree("{\"school\":\"9001\",\"address\":\"1234\"}"));
         when(queryDAO.findBySerial(52)).thenReturn(Optional.of(abcd));
         SingleResultView expected = mock(SingleResultView.class);
         when(viewFactory.getSingleResultView(abcd)).thenReturn(expected);
@@ -113,7 +113,7 @@ public class SearchResourceTest {
 
     @Test
     public void findBySerial_setsHistoryLinkHeader() throws Exception {
-        DbRecord abcd = new DbRecord("abcd", Jackson.newObjectMapper().readTree("{\"school\":\"9001\",\"address\":\"1234\"}"));
+        DbEntry abcd = new DbEntry("abcd", Jackson.newObjectMapper().readTree("{\"school\":\"9001\",\"address\":\"1234\"}"));
         when(queryDAO.findBySerial(52)).thenReturn(Optional.of(abcd));
         when(viewFactory.getSingleResultView(abcd)).thenReturn(mock(SingleResultView.class));
 


### PR DESCRIPTION
We've had a number of sessions recently where we've talked about coming
up with concrete names for various concepts in registers.  These are
starting to crystallise into a common language.  This commit brings the
code into line with the names we are using.  In particular:

An _Entry_ is:

> an immutable mapping from _fields_ to _values_ created at a point in
> time, identified by a _serial number_

A _Register_ is:

> an append-only list of _entries_, with a defined set of _fields_, one
> of which is the _primary key_

A _Record_ is:

> the set of all _entries_ in a _register_ who share the same _primary
> key_ value

In this commit, I've also started using the word _content_ to refer to
the bag of data that an _entry_ contains, independently of its position
within the register.  (A hash identifies some content; two entries with
different serial numbers can have the same content and the same hash.)

I also have steered clear of using `entry` to refer to instances of
`Map.Entry`, using the term `keyValue` instead.  I don't particularly
like this -- maybe `mapEntry` would be better?  But I think it's
important that we don't overload our _entry_ term if we can avoid it.
