### PR TITLE
tidy up templates

### DIFF
--- a/src/main/resources/templates/404.html
+++ b/src/main/resources/templates/404.html
@@ -1,23 +1,20 @@
-<!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-4.dtd">
+<!DOCTYPE html>
 
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="main.html::head"></head>
 <body>
-<header th:include="main.html::header" id="global-header"></header>
+<header th:replace="main.html::header"></header>
 
 <label style="font-family: Helvetica, Arial; font-weight: bold; font-size: 2.50rem;">Page not found</label>
 <br/>
 <br/>
-<label style="font-family: Helvetica, Arial; font-size: 1.00rem;">If you entered a web address please check it was correct.</label>
+<label style="font-family: Helvetica, Arial; font-size: 1.00rem;">If you entered a web address please check it was
+    correct.</label>
 <br/>
 <br/>
 
-<div class="row">
-    <div class="small-12 large-6 columns">
-        <div th:include="copyright.html::copyright"></div>
-    </div>
-</div>
+<div th:include="copyright.html::copyright"></div>
 
-<footer th:include="main.html::footer" id="footer" class="group" role="contentinfo"></footer>
+<footer th:replace="main.html::footer"></footer>
 </body>
 </html>

--- a/src/main/resources/templates/500.html
+++ b/src/main/resources/templates/500.html
@@ -1,9 +1,9 @@
-<!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-4.dtd">
+<!DOCTYPE html>
 
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="main.html::head"></head>
 <body>
-<header th:include="main.html::header" id="global-header"></header>
+<header th:replace="main.html::header"></header>
 
 <label style="font-family: Helvetica, Arial; font-weight: bold; font-size: 2.50rem;">Oops, looks like something went wrong</label>
 <br/>
@@ -12,12 +12,8 @@
 <br/>
 <br/>
 
-<div class="row">
-    <div class="small-12 large-6 columns">
-        <div th:include="copyright.html::copyright"></div>
-    </div>
-</div>
+<div th:include="copyright.html::copyright"></div>
 
-<footer th:include="main.html::footer" id="footer" class="group" role="contentinfo"></footer>
+<footer th:replace="main.html::footer"></footer>
 </body>
 </html>

--- a/src/main/resources/templates/data-formats.html
+++ b/src/main/resources/templates/data-formats.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml">
-<div class="row" th:fragment="data-formats">
+<div th:fragment="data-formats">
     <p class="data-representations">This data is available as:
              <span>
                 <a th:href="${@uk.gov.register.presentation.HtmlViewSupport@representationLink(#httpServletRequest, 'json')}">json</a>,

--- a/src/main/resources/templates/download.html
+++ b/src/main/resources/templates/download.html
@@ -3,7 +3,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="main.html::head"></head>
 <body>
-<header th:include="main.html::header" id="global-header"></header>
+<header th:replace="main.html::header"></header>
 
 <div class="row">
     <div class="small-12 large-8 columns">
@@ -18,7 +18,7 @@
     </div>
 </div>
 
-<div th:include="main.html::footer-wrapper"></div>
+<footer th:replace="main.html::footer"></footer>
 
 </body>
 </html>

--- a/src/main/resources/templates/entries.html
+++ b/src/main/resources/templates/entries.html
@@ -3,7 +3,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="main.html::head"></head>
 <body>
-<header th:include="main.html::header" id="global-header"></header>
+<header th:replace="main.html::header"></header>
 
 <div class="row entry-row">
     <div class="large-12 columns">
@@ -31,12 +31,8 @@
     </div>
 </div>
 
-<div class="row">
-    <div class="small-12 large-6 columns">
-        <div th:include="data-formats.html::data-formats"></div>
-    </div>
-</div>
+<div th:include="data-formats.html::data-formats"></div>
 
-<footer th:include="main.html::footer" id="footer" class="group" role="contentinfo"></footer>
+<footer th:replace="main.html::footer"></footer>
 </body>
 </html>

--- a/src/main/resources/templates/entry.html
+++ b/src/main/resources/templates/entry.html
@@ -3,7 +3,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="main.html::head"></head>
 <body>
-<header th:include="main.html::header" id="global-header"></header>
+<header th:replace="main.html::header"></header>
 <div class="row">
     <div class="small-12 large-8 columns">
         <h1 class="entry-header" th:text="${entry.primaryKey()}">Entry Name Header</h1>
@@ -41,25 +41,13 @@
 </div>
 <!-- /.row -->
 
-<div class="row">
-    <div class="small-12 large-6 columns">
-        <div th:include="data-formats.html::data-formats"></div>
-    </div>
-</div>
+<div th:include="data-formats.html::data-formats"></div>
 
-<div class="row">
-    <div class="small-12 large-6 columns">
-        <p>View all versions of this record <a th:href="${@uk.gov.register.presentation.HtmlViewSupport@extractLinkFromLinkHeader(#ctx.httpServletResponse.getHeader('Link'))}">here</a></p>
-    </div>
-</div>
+<p>View all versions of this record <a th:href="${@uk.gov.register.presentation.HtmlViewSupport@extractLinkFromLinkHeader(#ctx.httpServletResponse.getHeader('Link'))}">here</a></p>
 
 
-<div class="row">
-    <div class="small-12 large-6 columns">
-        <div th:include="copyright.html::copyright"></div>
-    </div>
-</div>
+<div th:include="copyright.html::copyright"></div>
 
-<footer th:include="main.html::footer" id="footer" class="group" role="contentinfo"></footer>
+<footer th:replace="main.html::footer"></footer>
 </body>
 </html>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -3,7 +3,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="main.html::head"></head>
 <body>
-<header th:include="main.html::header" id="global-header"></header>
+<header th:replace="main.html::header"></header>
 <main id="main" role="main">
     <div th:include="main.html::phase" class="phase-banner"></div>
     <h1>The register of UK government registers.</h1>
@@ -35,7 +35,7 @@
 
 </main>
 
-<footer th:include="main.html::footer" id="footer" class="group" role="contentinfo"></footer>
+<footer th:replace="main.html::footer"></footer>
 
 </body>
 </html>

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -31,7 +31,7 @@
     </p>
 </div>
 
-<footer th:fragment="footer">
+<footer th:fragment="footer" id="footer" class="group" role="contentinfo">
     <div class="footer-wrapper">
         <div class="footer-meta">
             <div class="footer-meta-inner">

--- a/src/main/resources/templates/not-implemented.html
+++ b/src/main/resources/templates/not-implemented.html
@@ -3,7 +3,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="main.html::head"></head>
 <body>
-<header th:include="main.html::header" id="global-header"></header>
+<header th:replace="main.html::header"></header>
 
 <div class="row">
     <div class="small-12 large-8 columns">
@@ -16,7 +16,7 @@
     </div>
 </div>
 
-<div th:include="main.html::footer-wrapper"></div>
+<footer th:replace="main.html::footer"></footer>
 
 </body>
 </html>

--- a/src/main/resources/templates/versions.html
+++ b/src/main/resources/templates/versions.html
@@ -3,7 +3,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="main.html::head"></head>
 <body>
-<header th:include="main.html::header" id="global-header"></header>
+<header th:replace="main.html::header"></header>
 
 <div class="row">
     <div class="small-12 large-12 columns">
@@ -24,12 +24,8 @@
     <!-- /.columns -->
 </div>
 <br/>
-<div class="row">
-    <div class="small-12 large-6 columns">
-        <div th:include="copyright.html::copyright"></div>
-    </div>
-</div>
+<div th:include="copyright.html::copyright"></div>
 
-<footer th:include="main.html::footer" id="footer" class="group" role="contentinfo"></footer>
+<footer th:replace="main.html::footer"></footer>
 </body>
 </html>


### PR DESCRIPTION
Two main things:
1. using th:replace instead of th:include for header and footer means we
   can specify the required ids, classes and roles in one place rather
   than everywhere
2. removing a bunch of unnecessary divs from the foundation era.  even
   if we want them back they should probably live in the fragment not
   the surrounding template
