### PR TITLE
Expose serial number in history

### DIFF
--- a/src/main/java/uk/gov/register/presentation/DbContent.java
+++ b/src/main/java/uk/gov/register/presentation/DbContent.java
@@ -1,0 +1,24 @@
+package uk.gov.register.presentation;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class DbContent {
+    final String hash;
+    final JsonNode jsonContent;
+
+    @JsonCreator
+    public DbContent(@JsonProperty("hash") String hash, @JsonProperty("entry") JsonNode jsonContent) {
+        this.hash = hash;
+        this.jsonContent = jsonContent;
+    }
+
+    public String getHash() {
+        return hash;
+    }
+
+    public JsonNode getContent() {
+        return jsonContent;
+    }
+}

--- a/src/main/java/uk/gov/register/presentation/DbEntry.java
+++ b/src/main/java/uk/gov/register/presentation/DbEntry.java
@@ -1,25 +1,20 @@
 package uk.gov.register.presentation;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-
 public class DbEntry {
-    private final String hash;
-    private final JsonNode jsonContent;
+    private final int serialNumber;
+    private final DbContent dbContent;
 
-    @JsonCreator
-    public DbEntry(@JsonProperty("hash") String hash, @JsonProperty("entry") JsonNode jsonContent) {
-        this.hash = hash;
-        this.jsonContent = jsonContent;
+    public DbEntry(int serialNumber, DbContent dbContent) {
+        this.serialNumber = serialNumber;
+        this.dbContent = dbContent;
     }
 
-    public String getHash() {
-        return hash;
+    public DbContent getContent() {
+        return dbContent;
     }
 
-    public JsonNode getContent() {
-        return jsonContent;
+    public int getSerialNumber() {
+        return serialNumber;
     }
 }
 

--- a/src/main/java/uk/gov/register/presentation/EntryConverter.java
+++ b/src/main/java/uk/gov/register/presentation/EntryConverter.java
@@ -24,9 +24,9 @@ public class EntryConverter {
     }
 
     public EntryView convert(DbEntry dbEntry) {
-        Iterable<Map.Entry<String, JsonNode>> fields = () -> dbEntry.getContent().fields();
+        Iterable<Map.Entry<String, JsonNode>> fields = () -> dbEntry.getContent().getContent().fields();
         Stream<Map.Entry<String, JsonNode>> fieldStream = StreamSupport.stream(fields.spliterator(), false);
-        return new EntryView(dbEntry.getHash(), requestContext.getRegisterPrimaryKey(), fieldStream.collect(Collectors.toMap(Map.Entry::getKey, this::convert)));
+        return new EntryView(dbEntry.getContent().getHash(), requestContext.getRegisterPrimaryKey(), fieldStream.collect(Collectors.toMap(Map.Entry::getKey, this::convert)));
     }
 
 

--- a/src/main/java/uk/gov/register/presentation/EntryConverter.java
+++ b/src/main/java/uk/gov/register/presentation/EntryConverter.java
@@ -26,7 +26,12 @@ public class EntryConverter {
     public EntryView convert(DbEntry dbEntry) {
         Iterable<Map.Entry<String, JsonNode>> fields = () -> dbEntry.getContent().getContent().fields();
         Stream<Map.Entry<String, JsonNode>> fieldStream = StreamSupport.stream(fields.spliterator(), false);
-        return new EntryView(dbEntry.getContent().getHash(), requestContext.getRegisterPrimaryKey(), fieldStream.collect(Collectors.toMap(Map.Entry::getKey, this::convert)));
+        return new EntryView(
+                dbEntry.getSerialNumber(),
+                dbEntry.getContent().getHash(),
+                requestContext.getRegisterPrimaryKey(),
+                fieldStream.collect(Collectors.toMap(Map.Entry::getKey, this::convert))
+        );
     }
 
 

--- a/src/main/java/uk/gov/register/presentation/EntryView.java
+++ b/src/main/java/uk/gov/register/presentation/EntryView.java
@@ -6,14 +6,16 @@ import java.util.Map;
 import java.util.Set;
 
 public class EntryView {
+    private final int serialNumber;
+    private final String hash;
     private final String registerName;
     private final Map<String, FieldValue> entryMap;
-    private String hash;
 
-    public EntryView(String hash, String registerName, Map<String, FieldValue> entryMap) {
+    public EntryView(int serialNumber, String hash, String registerName, Map<String, FieldValue> entryMap) {
         this.hash = hash;
         this.registerName = registerName;
         this.entryMap = entryMap;
+        this.serialNumber = serialNumber;
     }
 
 
@@ -29,6 +31,11 @@ public class EntryView {
 
     public FieldValue getField(String fieldName) {
         return entryMap.get(fieldName);
+    }
+
+    @SuppressWarnings("unused, used from html templates")
+    public int getSerialNumber() {
+        return serialNumber;
     }
 
     @SuppressWarnings("unused, used from html templates")

--- a/src/main/java/uk/gov/register/presentation/EntryView.java
+++ b/src/main/java/uk/gov/register/presentation/EntryView.java
@@ -33,7 +33,7 @@ public class EntryView {
         return entryMap.get(fieldName);
     }
 
-    @SuppressWarnings("unused, used from html templates")
+    @JsonProperty("serial-number")
     public int getSerialNumber() {
         return serialNumber;
     }

--- a/src/main/java/uk/gov/register/presentation/Version.java
+++ b/src/main/java/uk/gov/register/presentation/Version.java
@@ -5,8 +5,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class Version {
     @JsonProperty
     public final String hash;
+    @JsonProperty("serial-number")
+    public final int serialNumber;
 
-    public Version(String hash) {
+    public Version(int serialNumber, String hash) {
         this.hash = hash;
+        this.serialNumber = serialNumber;
     }
 }

--- a/src/main/java/uk/gov/register/presentation/dao/RecentEntryIndexQueryDAO.java
+++ b/src/main/java/uk/gov/register/presentation/dao/RecentEntryIndexQueryDAO.java
@@ -13,21 +13,21 @@ import java.util.Optional;
 @RegisterMapper(EntryMapper.class)
 public interface RecentEntryIndexQueryDAO {
 
-    @SqlQuery("SELECT entry FROM ordered_entry_index ORDER BY id DESC LIMIT :limit")
+    @SqlQuery("SELECT id,entry FROM ordered_entry_index ORDER BY id DESC LIMIT :limit")
     List<DbEntry> getAllEntries(@Bind("limit") int maxNumberToFetch);
 
-    @SqlQuery("SELECT entry FROM ordered_entry_index WHERE (entry #>> ARRAY['entry',:key]) = :value ORDER BY id DESC limit 1")
+    @SqlQuery("SELECT id,entry FROM ordered_entry_index WHERE (entry #>> ARRAY['entry',:key]) = :value ORDER BY id DESC limit 1")
     @SingleValueResult(DbEntry.class)
     Optional<DbEntry> findByKeyValue(@Bind("key") String key, @Bind("value") String value);
 
-    @SqlQuery("SELECT entry FROM ordered_entry_index WHERE (entry #>> ARRAY['entry',:key]) = :value ORDER BY id DESC")
+    @SqlQuery("SELECT id,entry FROM ordered_entry_index WHERE (entry #>> ARRAY['entry',:key]) = :value ORDER BY id DESC")
     List<DbEntry> findAllByKeyValue(@Bind("key") String key, @Bind("value") String value);
 
-    @SqlQuery("SELECT entry FROM ordered_entry_index WHERE (entry #>> ARRAY['hash']) = :hash")
+    @SqlQuery("SELECT id,entry FROM ordered_entry_index WHERE (entry #>> ARRAY['hash']) = :hash")
     @SingleValueResult(DbEntry.class)
     Optional<DbEntry> findByHash(@Bind("hash") String hash);
 
-    @SqlQuery("SELECT entry FROM ordered_entry_index WHERE id = :serial")
+    @SqlQuery("SELECT id,entry FROM ordered_entry_index WHERE id = :serial")
     @SingleValueResult(DbEntry.class)
     Optional<DbEntry> findBySerial(@Bind("serial") int serial);
 

--- a/src/main/java/uk/gov/register/presentation/mapper/EntryMapper.java
+++ b/src/main/java/uk/gov/register/presentation/mapper/EntryMapper.java
@@ -5,6 +5,7 @@ import com.google.common.base.Throwables;
 import io.dropwizard.jackson.Jackson;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
+import uk.gov.register.presentation.DbContent;
 import uk.gov.register.presentation.DbEntry;
 
 import java.io.IOException;
@@ -21,7 +22,7 @@ public class EntryMapper implements ResultSetMapper<DbEntry> {
     @Override
     public DbEntry map(int index, ResultSet r, StatementContext ctx) throws SQLException {
         try {
-            return objectMapper.readValue(r.getBytes("entry"), DbEntry.class);
+            return new DbEntry(r.getInt("id"), objectMapper.readValue(r.getBytes("entry"), DbContent.class));
         } catch (IOException e) {
             throw Throwables.propagate(e);
         }

--- a/src/main/java/uk/gov/register/presentation/representations/RepresentationWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/RepresentationWriter.java
@@ -3,7 +3,7 @@ package uk.gov.register.presentation.representations;
 import io.dropwizard.views.View;
 import uk.gov.register.presentation.EntryView;
 import uk.gov.register.presentation.view.ListResultView;
-import uk.gov.register.presentation.view.SingleResultView;
+import uk.gov.register.presentation.view.SingleEntryView;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
@@ -25,13 +25,13 @@ public abstract class RepresentationWriter implements MessageBodyWriter<View> {
 
     @Override
     public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
-        return SingleResultView.class.isAssignableFrom(type) || ListResultView.class.isAssignableFrom(type);
+        return SingleEntryView.class.isAssignableFrom(type) || ListResultView.class.isAssignableFrom(type);
     }
 
     @Override
     public void writeTo(View view, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
-        if (view instanceof SingleResultView) {
-            writeEntryTo(entityStream, ((SingleResultView) view).getEntry());
+        if (view instanceof SingleEntryView) {
+            writeEntryTo(entityStream, ((SingleEntryView) view).getEntry());
         }
         else {
             writeEntriesTo(entityStream, ((ListResultView) view).getEntries());

--- a/src/main/java/uk/gov/register/presentation/representations/SingleEntryJsonSerializer.java
+++ b/src/main/java/uk/gov/register/presentation/representations/SingleEntryJsonSerializer.java
@@ -4,13 +4,13 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import uk.gov.register.presentation.EntryView;
-import uk.gov.register.presentation.view.SingleResultView;
+import uk.gov.register.presentation.view.SingleEntryView;
 
 import java.io.IOException;
 
-public class SingleResultJsonSerializer extends JsonSerializer<SingleResultView> {
+public class SingleEntryJsonSerializer extends JsonSerializer<SingleEntryView> {
     @Override
-    public void serialize(SingleResultView value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(SingleEntryView value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
         EntryView entry = value.getEntry();
         JsonSerializer<Object> listSerializer = serializers.findValueSerializer(EntryView.class);
         listSerializer.serialize(entry, gen, serializers);

--- a/src/main/java/uk/gov/register/presentation/resource/HistoryResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/HistoryResource.java
@@ -42,7 +42,7 @@ public class HistoryResource {
         private final List<Version> versions;
 
         public ListVersionView(RequestContext requestContext, List<Version> versions) {
-            super(requestContext, "versions.html");
+            super(requestContext, "history.html");
             this.versions = versions;
         }
 

--- a/src/main/java/uk/gov/register/presentation/resource/HistoryResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/HistoryResource.java
@@ -32,7 +32,7 @@ public class HistoryResource {
     public ListVersionView history(@PathParam("primaryKey") String key, @PathParam("primaryKeyValue") String value) {
         String registerPrimaryKey = requestContext.getRegisterPrimaryKey();
         if (key.equals(registerPrimaryKey)) {
-            return new ListVersionView(requestContext, queryDAO.findAllByKeyValue(key, value).stream().map(r -> new Version(r.getHash())).collect(Collectors.toList()));
+            return new ListVersionView(requestContext, queryDAO.findAllByKeyValue(key, value).stream().map(r -> new Version(r.getSerialNumber(), r.getContent().getHash())).collect(Collectors.toList()));
         }
         throw new NotFoundException();
     }

--- a/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
@@ -4,13 +4,14 @@ import com.google.common.primitives.Ints;
 import uk.gov.register.presentation.DbEntry;
 import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
 import uk.gov.register.presentation.representations.ExtraMediaType;
-import uk.gov.register.presentation.view.SingleResultView;
+import uk.gov.register.presentation.view.SingleEntryView;
 import uk.gov.register.presentation.view.ViewFactory;
 
 import javax.inject.Inject;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import java.util.Optional;
+import java.util.function.Function;
 
 
 @Path("/")
@@ -30,34 +31,34 @@ public class SearchResource {
     @GET
     @Path("/{primaryKey}/{primaryKeyValue}")
     @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
-    public SingleResultView findByPrimaryKey(@PathParam("primaryKey") String key, @PathParam("primaryKeyValue") String value) {
+    public SingleEntryView findByPrimaryKey(@PathParam("primaryKey") String key, @PathParam("primaryKeyValue") String value) {
         if (!key.equals(requestContext.getRegisterPrimaryKey())) {
             throw new NotFoundException();
         }
         Optional<DbEntry> entryO = queryDAO.findByKeyValue(key, value);
-        return entryResponse(entryO);
+        return entryResponse(entryO, viewFactory::getLatestEntryView);
     }
 
     @GET
     @Path("/hash/{hash}")
     @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
-    public SingleResultView findByHash(@PathParam("hash") String hash) {
+    public SingleEntryView findByHash(@PathParam("hash") String hash) {
         Optional<DbEntry> entryO = queryDAO.findByHash(hash);
-        return entryResponse(entryO);
+        return entryResponse(entryO, viewFactory::getSingleEntryView);
     }
 
     @GET
     @Path("/entry/{serial}")
     @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
-    public SingleResultView findBySerial(@PathParam("serial") String serialString) {
+    public SingleEntryView findBySerial(@PathParam("serial") String serialString) {
         Optional<Integer> serial = Optional.ofNullable(Ints.tryParse(serialString));
         Optional<DbEntry> entryO = serial.flatMap(queryDAO::findBySerial);
-        return entryResponse(entryO);
+        return entryResponse(entryO, viewFactory::getSingleEntryView);
     }
 
-    private SingleResultView entryResponse(Optional<DbEntry> optionalEntry) {
+    private SingleEntryView entryResponse(Optional<DbEntry> optionalEntry, Function<DbEntry, SingleEntryView> convertToEntryView) {
         optionalEntry.ifPresent(this::setVersionHistoryLinkHeader);
-        return optionalEntry.map(viewFactory::getSingleResultView)
+        return optionalEntry.map(convertToEntryView)
                 .orElseThrow(NotFoundException::new);
     }
 

--- a/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
@@ -67,6 +67,6 @@ public class SearchResource {
                 getHttpServletResponse().
                 setHeader("Link", String.format("</%s/%s/history>;rel=\"version-history\"",
                         primaryKey,
-                        entry.getContent().get(primaryKey).textValue()));
+                        entry.getContent().getContent().get(primaryKey).textValue()));
     }
 }

--- a/src/main/java/uk/gov/register/presentation/view/SingleEntryView.java
+++ b/src/main/java/uk/gov/register/presentation/view/SingleEntryView.java
@@ -2,16 +2,21 @@ package uk.gov.register.presentation.view;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import uk.gov.register.presentation.EntryView;
-import uk.gov.register.presentation.representations.SingleResultJsonSerializer;
+import uk.gov.register.presentation.representations.SingleEntryJsonSerializer;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.register.thymeleaf.ThymeleafView;
 
-@JsonSerialize(using = SingleResultJsonSerializer.class)
-public class SingleResultView extends ThymeleafView {
+@JsonSerialize(using = SingleEntryJsonSerializer.class)
+public class SingleEntryView extends ThymeleafView {
     private final EntryView entryView;
 
-    SingleResultView(RequestContext requestContext, EntryView entryView) {
+    SingleEntryView(RequestContext requestContext, EntryView entryView) {
         super(requestContext, "entry.html");
+        this.entryView = entryView;
+    }
+
+    SingleEntryView(RequestContext requestContext, EntryView entryView, String templateName) {
+        super(requestContext, templateName);
         this.entryView = entryView;
     }
 

--- a/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
+++ b/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
@@ -21,8 +21,12 @@ public class ViewFactory {
         this.entryConverter = entryConverter;
     }
 
-    public SingleResultView getSingleResultView(DbEntry dbEntry) {
-        return new SingleResultView(requestContext, entryConverter.convert(dbEntry));
+    public SingleEntryView getSingleEntryView(DbEntry dbEntry) {
+        return new SingleEntryView(requestContext, entryConverter.convert(dbEntry));
+    }
+
+    public SingleEntryView getLatestEntryView(DbEntry dbEntry) {
+        return new SingleEntryView(requestContext, entryConverter.convert(dbEntry), "latest-entry-of-record.html");
     }
 
     public ListResultView getListResultView(List<DbEntry> allDbEntries) {

--- a/src/main/resources/templates/entry.html
+++ b/src/main/resources/templates/entry.html
@@ -6,7 +6,7 @@
 <header th:replace="main.html::header"></header>
 <main id="main" role="main">
     <div th:replace="main.html::phase"></div>
-    <h1 th:text="${entry.primaryKey()}">Entry Name Header</h1>
+    <h1 th:text="'Entry ' + ${entry.serialNumber}">Entry Name Header</h1>
     <p class="entry-source">
         An entry in the
         <a href="/" th:text="${@uk.gov.register.presentation.RegisterNameExtractor@capitalizedRegisterName(#httpServletRequest.getHeader('Host')) + ' register'}"></a>

--- a/src/main/resources/templates/entry.html
+++ b/src/main/resources/templates/entry.html
@@ -7,39 +7,22 @@
 <main id="main" role="main">
     <div th:replace="main.html::phase"></div>
     <h1 th:text="'Entry ' + ${entry.serialNumber}">Entry Name Header</h1>
+
     <p class="entry-source">
         An entry in the
         <a href="/" th:text="${@uk.gov.register.presentation.RegisterNameExtractor@capitalizedRegisterName(#httpServletRequest.getHeader('Host')) + ' register'}"></a>
     </p>
-    <p class="entry-hash">
-        <span class="entry-hash" th:text="${'hash: ' + entry.hash}"></span>
-        <a href="#" class="tooltips">
-            <span class="tooltips-icon">?</span>
-            <span class="tooltips-text">The hash is a unique identifier for each version of an entry</span>
-        </a>
-    </p>
 
-    <table class="entry">
-        <tbody>
-        <tr th:each="keyValue : ${entry.content}">
-            <td ><a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(keyValue.key)}" th:text="${keyValue.key}"></a></td>
-            <td th:if="${keyValue.value.isLink()}">
-                <a th:href="${keyValue.value.link()}" th:text="${keyValue.value.value()}"></a>
-            </td>
-            <td th:unless="${keyValue.value.isLink()}" th:text="${keyValue.value.value()}">
-            </td>
-        </tr>
-        </tbody>
-    </table>
+    <div th:include="fragments/entry-table.html :: entry-table (content = ${entry.content})"></div>
 
     <div th:include="data-formats.html::data-formats"></div>
 
     <p>View all versions of this record <a th:href="${@uk.gov.register.presentation.HtmlViewSupport@extractLinkFromLinkHeader(#ctx.httpServletResponse.getHeader('Link'))}">here</a></p>
 
+
     <div th:include="copyright.html::copyright"></div>
 
 </main>
-
 <footer th:replace="main.html::footer"></footer>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/entry-table.html
+++ b/src/main/resources/templates/fragments/entry-table.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+
+<html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml">
+<body>
+<div th:fragment="entry-table(content)">
+    <table class="entry">
+        <thead>
+        <tr>
+            <th>Field</th>
+            <th>Value</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="keyValue : ${content}">
+            <td><a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(keyValue.key)}"
+                   th:text="${keyValue.key}"></a></td>
+            <td th:if="${keyValue.value.isLink()}">
+                <a th:href="${keyValue.value.link()}" th:text="${keyValue.value.value()}"></a>
+            </td>
+            <td th:unless="${keyValue.value.isLink()}" th:text="${keyValue.value.value()}">
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/history.html
+++ b/src/main/resources/templates/history.html
@@ -3,17 +3,21 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="main.html::head"></head>
 <body>
-<header th:replace="main.html::header"></header>
+<header th:include="main.html::header"></header>
+<main id="main" role="main">
 
 <div class="row">
     <div class="small-12 large-12 columns">
         <table id="version-table">
-            <tbody  id="entry-table">
+            <tbody id="entry-table">
             <tr>
-                <td th:text="hash">
-                </td>
+                <th>serial number</th>
+                <th>hash</th>
             </tr>
             <tr th:each="version : ${versions}">
+                <td>
+                    <a th:href="${'/entry/' + version.serialNumber}" th:text="${version.serialNumber}"></a>
+                </td>
                 <td>
                     <a th:href="${'/hash/' + version.hash}" th:text="${version.hash}"></a>
                 </td>
@@ -25,7 +29,7 @@
 </div>
 <br/>
 <div th:include="copyright.html::copyright"></div>
-
+</main>
 <footer th:replace="main.html::footer"></footer>
 </body>
 </html>

--- a/src/main/resources/templates/history.html
+++ b/src/main/resources/templates/history.html
@@ -3,7 +3,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="main.html::head"></head>
 <body>
-<header th:include="main.html::header"></header>
+<header th:replace="main.html::header"></header>
 <main id="main" role="main">
 
 <div class="row">

--- a/src/main/resources/templates/latest-entry-of-record.html
+++ b/src/main/resources/templates/latest-entry-of-record.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+
+<html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml">
+<head th:include="main.html::head"></head>
+<body>
+<header th:include="main.html::header" id="global-header"></header>
+<div class="row">
+    <div class="small-12 large-8 columns">
+        <h1 class="entry-header" th:text="'Record ' + ${entry.primaryKey()}">Entry Name Header</h1>
+
+        <p class="entry-source">An entry in the <a href="/"
+                                                   th:text="${@uk.gov.register.presentation.RegisterNameExtractor@capitalizedRegisterName(#httpServletRequest.getHeader('Host')) + ' register'}"></a>
+        </p>
+
+        <p class="entry-hash">
+            <span class="entry-hash" th:text="${'hash: ' + entry.hash}"></span>
+            <a href="#" class="tooltips">
+                <span class="tooltips-icon">?</span>
+                <span class="tooltips-text">The hash is a unique identifier for each version of an entry</span>
+            </a>
+        </p>
+    </div>
+</div>
+
+<div class="row">
+    <div class="small-12 large-12 columns">
+        <table id="entry-table">
+            <tbody>
+            <tr th:each="keyValue : ${entry.content}">
+                <td ><a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(keyValue.key)}" th:text="${keyValue.key}"></a></td>
+                <td th:if="${keyValue.value.isLink()}">
+                    <a th:href="${keyValue.value.link()}" th:text="${keyValue.value.value()}"></a>
+                </td>
+                <td th:unless="${keyValue.value.isLink()}" th:text="${keyValue.value.value()}">
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+    <!-- /.columns -->
+</div>
+<!-- /.row -->
+
+<div class="row">
+    <div class="small-12 large-6 columns">
+        <div th:include="data-formats.html::data-formats"></div>
+    </div>
+</div>
+
+<div class="row">
+    <div class="small-12 large-6 columns">
+        <p>View all versions of this record <a th:href="${@uk.gov.register.presentation.HtmlViewSupport@extractLinkFromLinkHeader(#ctx.httpServletResponse.getHeader('Link'))}">here</a></p>
+    </div>
+</div>
+
+
+<div class="row">
+    <div class="small-12 large-6 columns">
+        <div th:include="copyright.html::copyright"></div>
+    </div>
+</div>
+
+<footer th:include="main.html::footer" id="footer" class="group" role="contentinfo"></footer>
+</body>
+</html>

--- a/src/main/resources/templates/latest-entry-of-record.html
+++ b/src/main/resources/templates/latest-entry-of-record.html
@@ -3,63 +3,25 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="main.html::head"></head>
 <body>
-<header th:include="main.html::header" id="global-header"></header>
-<div class="row">
-    <div class="small-12 large-8 columns">
-        <h1 class="entry-header" th:text="'Record ' + ${entry.primaryKey()}">Entry Name Header</h1>
+<header th:replace="main.html::header"></header>
+<main id="main" role="main">
+    <h1 class="entry-header" th:text="'Record ' + ${entry.primaryKey()}">Entry Name Header</h1>
 
-        <p class="entry-source">An entry in the <a href="/"
-                                                   th:text="${@uk.gov.register.presentation.RegisterNameExtractor@capitalizedRegisterName(#httpServletRequest.getHeader('Host')) + ' register'}"></a>
-        </p>
+    <p class="entry-source">A record in the <a href="/"
+                                               th:text="${@uk.gov.register.presentation.RegisterNameExtractor@capitalizedRegisterName(#httpServletRequest.getHeader('Host')) + ' register'}"></a>
+    </p>
+    <p>The latest entry for this record is:</p>
 
-        <p class="entry-hash">
-            <span class="entry-hash" th:text="${'hash: ' + entry.hash}"></span>
-            <a href="#" class="tooltips">
-                <span class="tooltips-icon">?</span>
-                <span class="tooltips-text">The hash is a unique identifier for each version of an entry</span>
-            </a>
-        </p>
-    </div>
-</div>
+    <div th:include="fragments/entry-table.html :: entry-table (content = ${entry.content})"></div>
 
-<div class="row">
-    <div class="small-12 large-12 columns">
-        <table id="entry-table">
-            <tbody>
-            <tr th:each="keyValue : ${entry.content}">
-                <td ><a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(keyValue.key)}" th:text="${keyValue.key}"></a></td>
-                <td th:if="${keyValue.value.isLink()}">
-                    <a th:href="${keyValue.value.link()}" th:text="${keyValue.value.value()}"></a>
-                </td>
-                <td th:unless="${keyValue.value.isLink()}" th:text="${keyValue.value.value()}">
-                </td>
-            </tr>
-            </tbody>
-        </table>
-    </div>
-    <!-- /.columns -->
-</div>
-<!-- /.row -->
+    <div th:include="data-formats.html::data-formats"></div>
 
-<div class="row">
-    <div class="small-12 large-6 columns">
-        <div th:include="data-formats.html::data-formats"></div>
-    </div>
-</div>
+    <p>View all versions of this record <a
+            th:href="${@uk.gov.register.presentation.HtmlViewSupport@extractLinkFromLinkHeader(#ctx.httpServletResponse.getHeader('Link'))}">here</a>
+    </p>
 
-<div class="row">
-    <div class="small-12 large-6 columns">
-        <p>View all versions of this record <a th:href="${@uk.gov.register.presentation.HtmlViewSupport@extractLinkFromLinkHeader(#ctx.httpServletResponse.getHeader('Link'))}">here</a></p>
-    </div>
-</div>
-
-
-<div class="row">
-    <div class="small-12 large-6 columns">
-        <div th:include="copyright.html::copyright"></div>
-    </div>
-</div>
-
-<footer th:include="main.html::footer" id="footer" class="group" role="contentinfo"></footer>
+    <div th:include="copyright.html::copyright"></div>
+</main>
+<footer th:replace="main.html::footer"></footer>
 </body>
 </html>

--- a/src/test/java/uk/gov/register/presentation/EntryConverterTest.java
+++ b/src/test/java/uk/gov/register/presentation/EntryConverterTest.java
@@ -26,7 +26,7 @@ public class EntryConverterTest {
         ObjectMapper objectMapper = Jackson.newObjectMapper();
         JsonNode jsonNode = objectMapper.readValue("{\"registry\":\"somevalue\"}", JsonNode.class);
 
-        EntryView entryView = entryConverter.convert(new DbEntry("somehash", jsonNode));
+        EntryView entryView = entryConverter.convert(new DbEntry(13, new DbContent("somehash", jsonNode)));
 
         assertThat(((LinkValue) entryView.getField("registry")).link(), equalTo("http://public-body.openregister.org/public-body/somevalue"));
     }

--- a/src/test/java/uk/gov/register/presentation/functional/FindEntityTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/FindEntityTest.java
@@ -1,6 +1,5 @@
 package uk.gov.register.presentation.functional;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.jackson.Jackson;
@@ -10,7 +9,6 @@ import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import javax.ws.rs.core.Response;
-
 import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -47,12 +45,15 @@ public class FindEntityTest extends FunctionalTestBase {
     }
 
     @Test
-    public void findByHash_shouldReturnEntryForTheGivenHash() throws IOException {
+    public void findByHash_shouldReturnEntryForTheGivenHash() throws Exception {
         Response response = getRequest("/hash/hash2.json");
 
         assertThat(response.getHeaderString("Link"), equalTo("</address/6789/history>;rel=\"version-history\""));
-        assertThat(OBJECT_MAPPER.readValue(response.readEntity(String.class), JsonNode.class),
-                equalTo(OBJECT_MAPPER.readValue("{\"hash\":\"hash2\",\"entry\":{\"name\":\"presley\",\"address\":\"6789\"}}", JsonNode.class)));
+        JSONAssert.assertEquals("{" +
+                "\"serial-number\":2," +
+                "\"hash\":\"hash2\"," +
+                "\"entry\":{\"name\":\"presley\",\"address\":\"6789\"}}"
+                , response.readEntity(String.class), false);
     }
 
     @Test
@@ -74,11 +75,16 @@ public class FindEntityTest extends FunctionalTestBase {
     }
 
     @Test
-    public void current_shouldReturnAllCurrentVersionsOnly() throws InterruptedException, IOException {
+    public void current_shouldReturnAllCurrentVersionsOnly() throws Exception {
         Response response = getRequest("/current.json");
 
         String jsonResponse = response.readEntity(String.class);
-        assertThat(OBJECT_MAPPER.readValue(jsonResponse, JsonNode.class),
-                equalTo(OBJECT_MAPPER.readValue("[{\"hash\":\"hash2\",\"entry\":{\"name\":\"presley\",\"address\":\"6789\"}},{\"hash\":\"hash3\",\"entry\":{\"name\":\"ellis\",\"address\":\"145678\"}},{\"hash\":\"hash1\",\"entry\":{\"name\":\"ellis\",\"address\":\"12345\"}}]", JsonNode.class)));
+        JSONAssert.assertEquals(jsonResponse,
+                "[" +
+                        "{\"serial-number\":2,\"hash\":\"hash2\",\"entry\":{\"name\":\"presley\",\"address\":\"6789\"}}," +
+                        "{\"serial-number\":3,\"hash\":\"hash3\",\"entry\":{\"name\":\"ellis\",\"address\":\"145678\"}}," +
+                        "{\"serial-number\":1,\"hash\":\"hash1\",\"entry\":{\"name\":\"ellis\",\"address\":\"12345\"}}" +
+                        "]"
+                , false);
     }
 }

--- a/src/test/java/uk/gov/register/presentation/functional/HistoryTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/HistoryTest.java
@@ -27,8 +27,8 @@ public class HistoryTest extends FunctionalTestBase {
 
         JSONAssert.assertEquals(
                 "[" +
-                        "{\"hash\":\"hash4\"}," +
-                        "{\"hash\":\"hash1\"}" +
+                        "{\"serial-number\":4,\"hash\":\"hash4\"}," +
+                        "{\"serial-number\":1,\"hash\":\"hash1\"}" +
                         "]",
                 response.readEntity(String.class),
                 JSONCompareMode.STRICT_ORDER

--- a/src/test/java/uk/gov/register/presentation/representations/CsvWriterTest.java
+++ b/src/test/java/uk/gov/register/presentation/representations/CsvWriterTest.java
@@ -26,7 +26,7 @@ public class CsvWriterTest {
                 );
 
 
-        EntryView entry = new EntryView("hash1", "registerName", entryMap);
+        EntryView entry = new EntryView(52, "hash1", "registerName", entryMap);
 
         TestOutputStream entityStream = new TestOutputStream();
 

--- a/src/test/java/uk/gov/register/presentation/representations/TsvWriterTest.java
+++ b/src/test/java/uk/gov/register/presentation/representations/TsvWriterTest.java
@@ -25,7 +25,7 @@ public class TsvWriterTest {
                 "key3", new StringValue("val\"ue3"),
                 "key4", new StringValue("value4")
         );
-        EntryView entry = new EntryView("hash1", "registerName", entryMap);
+        EntryView entry = new EntryView(52, "hash1", "registerName", entryMap);
 
         TestOutputStream entityStream = new TestOutputStream();
 

--- a/src/test/java/uk/gov/register/presentation/representations/TurtleWriterTest.java
+++ b/src/test/java/uk/gov/register/presentation/representations/TurtleWriterTest.java
@@ -39,7 +39,7 @@ public class TurtleWriterTest {
                         "name", new StringValue("foo")
                 );
 
-        EntryView entry = new EntryView("abcd", "registerName", entryMap);
+        EntryView entry = new EntryView(52, "abcd", "registerName", entryMap);
 
         TestOutputStream entityStream = new TestOutputStream();
 

--- a/src/test/java/uk/gov/register/presentation/resource/HistoryResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/HistoryResourceTest.java
@@ -1,28 +1,66 @@
 package uk.gov.register.presentation.resource;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jackson.Jackson;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.register.presentation.DbContent;
+import uk.gov.register.presentation.DbEntry;
+import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
 
 import javax.ws.rs.NotFoundException;
 
-import static org.junit.Assert.fail;
+import java.util.Arrays;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
 public class HistoryResourceTest {
-    @Test
-    public void history_throwsNotFoundExceptionForNonPrimaryKeyRequests() {
-        RequestContext requestContext = new RequestContext() {
+
+    private HistoryResource resource;
+    @Mock
+    private RecentEntryIndexQueryDAO queryDAO;
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setUp() throws Exception {
+        resource = new HistoryResource(new RequestContext() {
             @Override
             public String getRegisterPrimaryKey() {
-                return "localhost";
+                return "school";
             }
-        };
+        }, queryDAO);
+        objectMapper = Jackson.newObjectMapper();
+    }
 
-        HistoryResource resource = new HistoryResource(requestContext, null);
-
+    @Test
+    public void history_throwsNotFoundExceptionForNonPrimaryKeyRequests() {
         try {
             resource.history("someOtherKey", "value");
             fail("Must fail");
         } catch (NotFoundException e) {
             //success
         }
+    }
+
+    @Test
+    public void history_returnsVersionsFromDatabase() throws Exception {
+        when(queryDAO.findAllByKeyValue("school", "1234")).thenReturn(Arrays.asList(
+                new DbEntry(3, new DbContent("hash1", objectMapper.readTree("{\"school\":\"1234\",\"head-teacher\":\"John Smith\"}"))),
+                new DbEntry(17, new DbContent("hash2", objectMapper.readTree("{\"school\":\"1234\",\"head-teacher\":\"Caroline Atkins\"}")))
+        ));
+
+        HistoryResource.ListVersionView history = resource.history("school", "1234");
+
+        assertThat(history.getVersions().get(0).hash, equalTo("hash1"));
+        assertThat(history.getVersions().get(0).serialNumber, equalTo(3));
+        assertThat(history.getVersions().get(1).hash, equalTo("hash2"));
+        assertThat(history.getVersions().get(1).serialNumber, equalTo(17));
     }
 }

--- a/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.register.presentation.DbContent;
 import uk.gov.register.presentation.DbEntry;
 import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
 import uk.gov.register.presentation.representations.ExtraMediaType;
@@ -101,7 +102,7 @@ public class SearchResourceTest {
 
     @Test
     public void findBySerial_findsEntryFromDb() throws Exception {
-        DbEntry abcd = new DbEntry("abcd", Jackson.newObjectMapper().readTree("{\"school\":\"9001\",\"address\":\"1234\"}"));
+        DbEntry abcd = new DbEntry(52, new DbContent("abcd", Jackson.newObjectMapper().readTree("{\"school\":\"9001\",\"address\":\"1234\"}")));
         when(queryDAO.findBySerial(52)).thenReturn(Optional.of(abcd));
         SingleResultView expected = mock(SingleResultView.class);
         when(viewFactory.getSingleResultView(abcd)).thenReturn(expected);
@@ -113,7 +114,7 @@ public class SearchResourceTest {
 
     @Test
     public void findBySerial_setsHistoryLinkHeader() throws Exception {
-        DbEntry abcd = new DbEntry("abcd", Jackson.newObjectMapper().readTree("{\"school\":\"9001\",\"address\":\"1234\"}"));
+        DbEntry abcd = new DbEntry(52, new DbContent("abcd", Jackson.newObjectMapper().readTree("{\"school\":\"9001\",\"address\":\"1234\"}")));
         when(queryDAO.findBySerial(52)).thenReturn(Optional.of(abcd));
         when(viewFactory.getSingleResultView(abcd)).thenReturn(mock(SingleResultView.class));
 

--- a/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
@@ -10,7 +10,7 @@ import uk.gov.register.presentation.DbContent;
 import uk.gov.register.presentation.DbEntry;
 import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
 import uk.gov.register.presentation.representations.ExtraMediaType;
-import uk.gov.register.presentation.view.SingleResultView;
+import uk.gov.register.presentation.view.SingleEntryView;
 import uk.gov.register.presentation.view.ViewFactory;
 
 import javax.servlet.http.HttpServletResponse;
@@ -104,10 +104,10 @@ public class SearchResourceTest {
     public void findBySerial_findsEntryFromDb() throws Exception {
         DbEntry abcd = new DbEntry(52, new DbContent("abcd", Jackson.newObjectMapper().readTree("{\"school\":\"9001\",\"address\":\"1234\"}")));
         when(queryDAO.findBySerial(52)).thenReturn(Optional.of(abcd));
-        SingleResultView expected = mock(SingleResultView.class);
-        when(viewFactory.getSingleResultView(abcd)).thenReturn(expected);
+        SingleEntryView expected = mock(SingleEntryView.class);
+        when(viewFactory.getSingleEntryView(abcd)).thenReturn(expected);
 
-        SingleResultView result = resource.findBySerial("52");
+        SingleEntryView result = resource.findBySerial("52");
 
         assertThat(result, equalTo(expected));
     }
@@ -116,7 +116,7 @@ public class SearchResourceTest {
     public void findBySerial_setsHistoryLinkHeader() throws Exception {
         DbEntry abcd = new DbEntry(52, new DbContent("abcd", Jackson.newObjectMapper().readTree("{\"school\":\"9001\",\"address\":\"1234\"}")));
         when(queryDAO.findBySerial(52)).thenReturn(Optional.of(abcd));
-        when(viewFactory.getSingleResultView(abcd)).thenReturn(mock(SingleResultView.class));
+        when(viewFactory.getSingleEntryView(abcd)).thenReturn(mock(SingleEntryView.class));
 
         resource.findBySerial("52");
 

--- a/src/test/resources/fixtures/list.yaml
+++ b/src/test/resources/fixtures/list.yaml
@@ -1,10 +1,12 @@
 ---
-- hash: "someHash2"
+- serial-number: 2
+  hash: "someHash2"
   entry:
     area: "value2"
     address: "67890"
     name: "The Entry 2"
-- hash: "someHash1"
+- serial-number: 1
+  hash: "someHash1"
   entry:
     area: "value1"
     address: "12345"

--- a/src/test/resources/fixtures/single.yaml
+++ b/src/test/resources/fixtures/single.yaml
@@ -1,4 +1,5 @@
 ---
+serial-number: 1
 hash: "someHash1"
 entry:
   area: "value1"


### PR DESCRIPTION
possibly easier to read individual commits, but in summary this PR:
- presents the serial number of an entry on the history page, and links to the /entry url
- splits the entry and record page templates, making the content (marginally different)
- exposes the serial number in the JSON and YAML representations (though not turtle at this stage)
