### PR TITLE
try to fix unicode issues

### DIFF
--- a/src/main/java/uk/gov/register/presentation/representations/ExtraMediaType.java
+++ b/src/main/java/uk/gov/register/presentation/representations/ExtraMediaType.java
@@ -3,6 +3,8 @@ package uk.gov.register.presentation.representations;
 import javax.ws.rs.core.MediaType;
 
 public class ExtraMediaType {
+    public static final String TEXT_HTML = "text/html; charset=utf-8";
+
     public static final String TEXT_CSV = "text/csv; charset=utf-8";
     public static final MediaType TEXT_CSV_TYPE = new MediaType("text", "csv", "utf-8");
     public static final String TEXT_TSV = "text/tab-separated-values; charset=utf-8";

--- a/src/main/java/uk/gov/register/presentation/resource/DataResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/DataResource.java
@@ -37,14 +37,14 @@ public class DataResource {
 
     @GET
     @Path("/download")
-    @Produces(MediaType.TEXT_HTML)
+    @Produces(ExtraMediaType.TEXT_HTML)
     public View download() {
         return viewFactory.thymeleafView("download.html");
     }
 
     @GET
     @Path("/download.torrent")
-    @Produces(MediaType.TEXT_HTML)
+    @Produces(ExtraMediaType.TEXT_HTML)
     public Response downloadTorrent() {
         return Response
                 .status(Response.Status.NOT_IMPLEMENTED)
@@ -54,7 +54,7 @@ public class DataResource {
 
     @GET
     @Path("/feed")
-    @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
+    @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
     public EntryListView feed(@QueryParam("pageIndex") Optional<Long> pageIndex, @QueryParam("pageSize") Optional<Long> pageSize) {
         Pagination pagination = new Pagination(pageIndex, pageSize, queryDAO.getEstimatedEntriesCount());
 
@@ -68,7 +68,7 @@ public class DataResource {
 
     @GET
     @Path("/current")
-    @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
+    @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
     public EntryListView current() {
         return viewFactory.getRecordEntriesView(queryDAO.getLatestEntriesOfRecords(requestContext.getRegisterPrimaryKey(), ENTRY_LIMIT));
     }

--- a/src/main/java/uk/gov/register/presentation/resource/HistoryResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/HistoryResource.java
@@ -1,18 +1,18 @@
 package uk.gov.register.presentation.resource;
 
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import uk.gov.register.presentation.Version;
 import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
+import uk.gov.register.presentation.representations.ExtraMediaType;
 import uk.gov.register.thymeleaf.ThymeleafView;
 
 import javax.inject.Inject;
-import javax.ws.rs.*;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -29,7 +29,7 @@ public class HistoryResource {
 
     @GET
     @Path("/{primaryKey}/{primaryKeyValue}/history")
-    @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON})
+    @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON})
     public ListVersionView history(@PathParam("primaryKey") String key, @PathParam("primaryKeyValue") String value) {
         String registerPrimaryKey = requestContext.getRegisterPrimaryKey();
         if (key.equals(registerPrimaryKey)) {

--- a/src/main/java/uk/gov/register/presentation/resource/HomePageResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/HomePageResource.java
@@ -1,6 +1,7 @@
 package uk.gov.register.presentation.resource;
 
 import io.dropwizard.views.View;
+import uk.gov.register.presentation.representations.ExtraMediaType;
 import uk.gov.register.presentation.view.ViewFactory;
 
 import javax.inject.Inject;
@@ -19,7 +20,7 @@ public class HomePageResource {
     }
 
     @GET
-    @Produces({MediaType.TEXT_HTML})
+    @Produces({ExtraMediaType.TEXT_HTML})
     public View home() {
         return viewFactory.thymeleafView("home.html");
     }

--- a/src/main/java/uk/gov/register/presentation/resource/NotFoundExceptionMapper.java
+++ b/src/main/java/uk/gov/register/presentation/resource/NotFoundExceptionMapper.java
@@ -1,11 +1,11 @@
 package uk.gov.register.presentation.resource;
 
+import uk.gov.register.presentation.representations.ExtraMediaType;
 import uk.gov.register.presentation.view.ViewFactory;
 
 import javax.inject.Inject;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
@@ -19,7 +19,7 @@ public class NotFoundExceptionMapper implements ExceptionMapper<NotFoundExceptio
 
     public Response toResponse(NotFoundException exception) {
         return Response.status(Response.Status.NOT_FOUND)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_HTML)
+                .header(HttpHeaders.CONTENT_TYPE, ExtraMediaType.TEXT_HTML)
                 .entity(viewFactory.thymeleafView("404.html"))
                 .build();
     }

--- a/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
@@ -30,7 +30,7 @@ public class SearchResource {
 
     @GET
     @Path("/{primaryKey}/{primaryKeyValue}")
-    @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
+    @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
     public SingleEntryView findByPrimaryKey(@PathParam("primaryKey") String key, @PathParam("primaryKeyValue") String value) {
         if (!key.equals(requestContext.getRegisterPrimaryKey())) {
             throw new NotFoundException();
@@ -41,7 +41,7 @@ public class SearchResource {
 
     @GET
     @Path("/hash/{hash}")
-    @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
+    @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
     public SingleEntryView findByHash(@PathParam("hash") String hash) {
         Optional<DbEntry> entryO = queryDAO.findByHash(hash);
         return entryResponse(entryO, viewFactory::getSingleEntryView);
@@ -49,7 +49,7 @@ public class SearchResource {
 
     @GET
     @Path("/entry/{serial}")
-    @Produces({MediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
+    @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
     public SingleEntryView findBySerial(@PathParam("serial") String serialString) {
         Optional<Integer> serial = Optional.ofNullable(Ints.tryParse(serialString));
         Optional<DbEntry> entryO = serial.flatMap(queryDAO::findBySerial);

--- a/src/main/java/uk/gov/register/presentation/resource/ThrowableExceptionMapper.java
+++ b/src/main/java/uk/gov/register/presentation/resource/ThrowableExceptionMapper.java
@@ -2,11 +2,11 @@ package uk.gov.register.presentation.resource;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.register.presentation.representations.ExtraMediaType;
 import uk.gov.register.presentation.view.ViewFactory;
 
 import javax.inject.Inject;
 import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 
@@ -26,7 +26,7 @@ public class ThrowableExceptionMapper implements ExceptionMapper<Throwable> {
         LOGGER.warn("Uncaught exception: {}", exception);
 
         return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_HTML)
+                .header(HttpHeaders.CONTENT_TYPE, ExtraMediaType.TEXT_HTML)
                 .entity(viewFactory.thymeleafView("500.html"))
                 .build();
     }

--- a/src/main/java/uk/gov/register/thymeleaf/ThymeleafViewRenderer.java
+++ b/src/main/java/uk/gov/register/thymeleaf/ThymeleafViewRenderer.java
@@ -40,6 +40,7 @@ public class ThymeleafViewRenderer implements ViewRenderer {
 
         templateResolver.setTemplateMode(templateMode);
         templateResolver.setCacheable(cacheable);
+        templateResolver.setCharacterEncoding("UTF-8");
         engine = new TemplateEngine();
         engine.setTemplateResolver(templateResolver);
 

--- a/src/test/java/uk/gov/register/presentation/functional/ApplicationTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/ApplicationTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
@@ -39,5 +40,16 @@ public class ApplicationTest extends FunctionalTestBase {
                 .get();
 
         assertThat(response.getHeaders().get(HttpHeaders.CONTENT_SECURITY_POLICY), equalTo(ImmutableList.of("default-src 'self'")));
+    }
+
+    @Test
+    public void appExplicitlySendsHtmlCharsetInHeader() throws Exception {
+        Response response = client.target("http://address.openregister.dev:" + APPLICATION_PORT + "/feed")
+                .request()
+                .get();
+
+        String contentType = (String) response.getHeaders().get(HttpHeaders.CONTENT_TYPE).get(0);
+        assertThat(contentType, containsString("text/html"));
+        assertThat(contentType, containsString("charset=utf-8"));
     }
 }

--- a/src/test/java/uk/gov/register/presentation/resource/DataResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/DataResourceTest.java
@@ -51,6 +51,7 @@ public class DataResourceTest {
         List<String> declaredMediaTypes = asList(feedMethod.getAnnotation(Produces.class).value());
         assertThat(declaredMediaTypes, hasItems(
                 MediaType.APPLICATION_JSON,
+                ExtraMediaType.TEXT_HTML,
                 ExtraMediaType.TEXT_CSV,
                 ExtraMediaType.TEXT_TSV,
                 ExtraMediaType.TEXT_TTL
@@ -63,7 +64,7 @@ public class DataResourceTest {
         List<String> declaredMediaTypes = asList(allMethod.getAnnotation(Produces.class).value());
         assertThat(declaredMediaTypes, hasItems(
                 MediaType.APPLICATION_JSON,
-                MediaType.TEXT_HTML,
+                ExtraMediaType.TEXT_HTML,
                 ExtraMediaType.TEXT_CSV,
                 ExtraMediaType.TEXT_TSV,
                 ExtraMediaType.TEXT_TTL

--- a/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
@@ -154,7 +154,7 @@ public class SearchResourceTest {
         Method searchMethod = SearchResource.class.getDeclaredMethod("findByPrimaryKey", String.class, String.class);
         List<String> declaredMediaTypes = asList(searchMethod.getDeclaredAnnotation(Produces.class).value());
         assertThat(declaredMediaTypes,
-                hasItems(MediaType.TEXT_HTML,
+                hasItems(ExtraMediaType.TEXT_HTML,
                         MediaType.APPLICATION_JSON,
                         ExtraMediaType.TEXT_TTL));
     }
@@ -164,7 +164,7 @@ public class SearchResourceTest {
         Method findByPrimaryKeyMethod = SearchResource.class.getDeclaredMethod("findByHash", String.class);
         List<String> declaredMediaTypes = asList(findByPrimaryKeyMethod.getDeclaredAnnotation(Produces.class).value());
         assertThat(declaredMediaTypes,
-                hasItems(MediaType.TEXT_HTML,
+                hasItems(ExtraMediaType.TEXT_HTML,
                         MediaType.APPLICATION_JSON,
                         ExtraMediaType.TEXT_TTL));
     }
@@ -174,7 +174,7 @@ public class SearchResourceTest {
         Method findByPrimaryKeyMethod = SearchResource.class.getDeclaredMethod("findBySerial", String.class);
         List<String> declaredMediaTypes = asList(findByPrimaryKeyMethod.getDeclaredAnnotation(Produces.class).value());
         assertThat(declaredMediaTypes,
-                hasItems(MediaType.TEXT_HTML,
+                hasItems(ExtraMediaType.TEXT_HTML,
                         MediaType.APPLICATION_JSON,
                         ExtraMediaType.TEXT_TTL));
     }


### PR DESCRIPTION
The `/download.torrent` not implemented page has weird unicode problems -- wherever a non-ascii unicode char appears in the template source, we instead render a series of question marks.  This seems to only happen on the aws environment, not locally.  This might be an OS X / linux difference?

Anyway this PR tries to fix the thymeleaf rendering, and also as a bonus ensures that we always set a charset in the content-type header.
