### PR TITLE
hacky fix to deployment validation

### DIFF
--- a/deploy/scripts/validate.sh
+++ b/deploy/scripts/validate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-while [[ `curl -s -o /dev/null -w "%{http_code}" http://localhost/` != "200" ]]
+while [[ `curl -s -o /dev/null -w "%{http_code}" --resolve country.openregister.org:80:127.0.0.1 http://country.openregister.org/` != "200" ]]
 do
     echo "Sleeping 5 seconds and then retry"
     sleep 5


### PR DESCRIPTION
the validation script fails because the app is looking for a "localhost"
register in the RegistersConfiguration (merged in b2dd5a99eaff0faee384f
in PR #78).  This hardcodes the validation script to pretend the
register is the country register just to get things working again.  The
longer-term solution is probably to use the dropwizard healthcheck
endpoint for validation.
