### PR TITLE
better solution to deploy validation

### DIFF
--- a/deploy/scripts/validate.sh
+++ b/deploy/scripts/validate.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -e
 
-while [[ `curl -s -o /dev/null -w "%{http_code}" --resolve country.openregister.org:80:127.0.0.1 http://country.openregister.org/` != "200" ]]
+container_ip=$(docker inspect -f '{{.NetworkSettings.IPAddress}}' presentationApp)
+
+while ! curl -sf -o /dev/null http://${container_ip}:8081/healthcheck
 do
     echo "Sleeping 5 seconds and then retry"
     sleep 5


### PR DESCRIPTION
This validate script works by hitting [dropwizard's healthcheck endpoint](https://dropwizard.github.io/dropwizard/manual/core.html#health-checks).
The curl command is slightly simplified by using the `-f` flag to cause
curl to fail if the http status is 400 or greater.

Because the healthcheck endpoint is on a separate port that isn't
exposed to the world, we do some docker jiggery pokery to get the
container's IP address in order to hit port 8081.
