### PR TITLE
Throwing 404 when total entries are less than requested in page query parameters

### DIFF
--- a/src/main/java/uk/gov/register/presentation/resource/Pagination.java
+++ b/src/main/java/uk/gov/register/presentation/resource/Pagination.java
@@ -2,6 +2,7 @@ package uk.gov.register.presentation.resource;
 
 
 import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotFoundException;
 import java.util.Optional;
 
 public class Pagination {
@@ -11,15 +12,19 @@ public class Pagination {
     private final long totalEntries;
     private final long pageSize;
 
-    Pagination(String resourcePath, Optional<Long> pageIndex, Optional<Long> pageSize, long totalEntries) {
+    Pagination(String resourcePath, Optional<Long> optionalPageIndex, Optional<Long> optionalPageSize, long totalEntries) {
         this.resourcePath = resourcePath;
         this.totalEntries = totalEntries;
 
-        this.pageIndex = pageIndex.orElse(1L);
-        this.pageSize = pageSize.orElse(DataResource.ENTRY_LIMIT);
+        this.pageIndex = optionalPageIndex.orElse(1L);
+        this.pageSize = optionalPageSize.orElse(DataResource.ENTRY_LIMIT);
 
         if (this.pageSize <= 0 || this.pageIndex <= 0) {
             throw new BadRequestException();
+        }
+
+        if ((this.pageIndex - 1) * this.pageSize >= totalEntries) {
+            throw new NotFoundException();
         }
     }
 

--- a/src/test/java/uk/gov/register/presentation/functional/ApplicationTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/ApplicationTest.java
@@ -50,6 +50,6 @@ public class ApplicationTest extends FunctionalTestBase {
 
         String contentType = (String) response.getHeaders().get(HttpHeaders.CONTENT_TYPE).get(0);
         assertThat(contentType, containsString("text/html"));
-        assertThat(contentType, containsString("charset=utf-8"));
+        assertThat(contentType, containsString("charset=UTF-8"));
     }
 }

--- a/src/test/java/uk/gov/register/presentation/resource/PaginationTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/PaginationTest.java
@@ -3,6 +3,7 @@ package uk.gov.register.presentation.resource;
 import org.junit.Test;
 
 import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotFoundException;
 import java.util.Optional;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -48,7 +49,7 @@ public class PaginationTest {
     }
 
     @Test
-    public void hasPreviousPage_returnsTrueOnlyWhenPageIndexIsMopreThanOne() {
+    public void hasPreviousPage_returnsTrueOnlyWhenPageIndexIsMoreThanOne() {
         assertFalse(new Pagination("/feed", Optional.of(1l), Optional.of(10l), 10).hasPreviousPage());
         assertFalse(new Pagination("/feed", Optional.of(1l), Optional.of(10l), 11).hasPreviousPage());
 
@@ -84,5 +85,10 @@ public class PaginationTest {
     public void getPreviousPageLink_returnsTheLinkForPreviousPage() {
         Pagination pagination = new Pagination("/feed", Optional.of(2l), Optional.of(10l), 11);
         assertThat(pagination.getPreviousPageLink(), equalTo("/feed?pageIndex=1&pageSize=10"));
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void construct_throwsNotFoundException_whenNoMoreEntriesForGivenPageSizeAndPageIndexValues() {
+        new Pagination("/feed", Optional.of(2l), Optional.of(10l), 10);
     }
 }


### PR DESCRIPTION
This PR make sure that we throw NotFoundException there are not many entries available requested by page query parameters.

For example:

When user is requesting second page with 10 entries per page. we will return 404 if total entries are only 10 or less because in this case second page is not available. 
