### PR TITLE
Inline region in aws commands

### DIFF
--- a/deploy/scripts/start-service.sh
+++ b/deploy/scripts/start-service.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 INSTANCE_ID=$(curl 169.254.169.254/2014-11-05/meta-data/instance-id)
-export AWS_DEFAULT_REGION=eu-west-1
-REGISTER_NAME=$(aws ec2 describe-tags --filters Name=resource-id,Values=$INSTANCE_ID Name=key,Values=Name --query 'Tags[0].Value' --output text)
-ENV=$(aws ec2 describe-tags --filters Name=resource-id,Values=$INSTANCE_ID Name=key,Values=Environment --query 'Tags[0].Value' --output text)
+REGISTER_NAME=$(aws ec2 describe-tags --filters Name=resource-id,Values=$INSTANCE_ID Name=key,Values=Name --query 'Tags[0].Value' --output text --region eu-west-1)
+ENV=$(aws ec2 describe-tags --filters Name=resource-id,Values=$INSTANCE_ID Name=key,Values=Environment --query 'Tags[0].Value' --output text --region eu-west-1)
 CONFIG_BUCKET=openregister.${ENV}.config
 
 aws s3 cp s3://${CONFIG_BUCKET}/${REGISTER_NAME}/presentation/config.yaml /srv/presentation --region eu-west-1


### PR DESCRIPTION
Specifying AWS_DEFAULT_REGION environment variable was not working so inlined with aws command. I think it does not work when using IAM role for AWS resource access.
