### PR TITLE
bug: html view for register register was broken

### DIFF
--- a/src/main/java/uk/gov/register/presentation/ListValue.java
+++ b/src/main/java/uk/gov/register/presentation/ListValue.java
@@ -2,6 +2,7 @@ package uk.gov.register.presentation;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 import java.util.Iterator;
 import java.util.List;
@@ -21,7 +22,7 @@ public class ListValue implements FieldValue, Iterable<FieldValue> {
     @Override
     @JsonIgnore
     public String getValue() {
-        throw new UnsupportedOperationException();
+        return "[ " + String.join(", ", Lists.transform(elements, FieldValue::getValue)) + " ]";
     }
 
     @Override


### PR DESCRIPTION
 After introducing the ListValue class html view of register register was broken because it is only register which has fields whose value is a list. getValue() method of ListValue was not implemented so html was unable to render.
   Changes in this commit renders fields as plain text list of fields, these are not linked to field register. There is more work needed to achieve this.
