### PR TITLE
Using character encoding constant instead of specifying raw string

### DIFF
--- a/src/main/java/uk/gov/register/presentation/representations/CsvWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/CsvWriter.java
@@ -10,6 +10,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -19,7 +20,7 @@ public class CsvWriter extends RepresentationWriter {
     @Override
     protected void writeEntriesTo(OutputStream entityStream, Register register, List<EntryView> entries) throws IOException, WebApplicationException {
         Iterable<String> fields = register.getFields();
-        entityStream.write(("entry," + String.join(",", fields) + "\r\n").getBytes("utf-8"));
+        entityStream.write(("entry," + String.join(",", fields) + "\r\n").getBytes(StandardCharsets.UTF_8));
         for (EntryView entry : entries) {
             writeRow(entityStream, fields, entry);
         }
@@ -29,7 +30,7 @@ public class CsvWriter extends RepresentationWriter {
         String row = StreamSupport.stream(fields.spliterator(),false)
                 .map(field -> escape(entry.getField(field).map(this::renderField).orElse("")))
                 .collect(Collectors.joining(",", entry.getSerialNumber() + ",", "\r\n"));
-        entityStream.write(row.getBytes("utf-8"));
+        entityStream.write(row.getBytes(StandardCharsets.UTF_8));
     }
 
     private String renderField(FieldValue fieldValue) {

--- a/src/main/java/uk/gov/register/presentation/representations/TsvWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/TsvWriter.java
@@ -9,6 +9,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -18,7 +19,7 @@ public class TsvWriter extends RepresentationWriter {
     @Override
     protected void writeEntriesTo(OutputStream entityStream, Register register, List<EntryView> entries) throws IOException, WebApplicationException {
         Iterable<String> fields = register.getFields();
-        entityStream.write(("entry\t" + String.join("\t", fields) + "\n").getBytes("utf-8"));
+        entityStream.write(("entry\t" + String.join("\t", fields) + "\n").getBytes(StandardCharsets.UTF_8));
         for (EntryView entry : entries) {
             writeRow(entityStream, fields, entry);
         }
@@ -28,7 +29,7 @@ public class TsvWriter extends RepresentationWriter {
         String row = StreamSupport.stream(fields.spliterator(),false)
                 .map(field -> entry.getField(field).map(this::renderField).orElse(""))
                 .collect(Collectors.joining("\t", entry.getSerialNumber() + "\t", "\n"));
-        entityStream.write(row.getBytes("utf-8"));
+        entityStream.write(row.getBytes(StandardCharsets.UTF_8));
     }
 
     private String renderField(FieldValue fieldValue) {

--- a/src/main/java/uk/gov/register/presentation/representations/TurtleWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/TurtleWriter.java
@@ -14,6 +14,7 @@ import javax.ws.rs.core.UriBuilder;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -35,9 +36,9 @@ public class TurtleWriter extends RepresentationWriter {
     @Override
     protected void writeEntriesTo(OutputStream entityStream, Register register, List<EntryView> entries) throws IOException {
         Iterable<String> fields = register.getFields();
-        entityStream.write(PREFIX.getBytes("utf-8"));
+        entityStream.write(PREFIX.getBytes(StandardCharsets.UTF_8));
         for (EntryView entry : entries) {
-            entityStream.write((renderEntry(entry, fields) + "\n").getBytes("utf-8"));
+            entityStream.write((renderEntry(entry, fields) + "\n").getBytes(StandardCharsets.UTF_8));
         }
     }
 

--- a/src/main/java/uk/gov/register/thymeleaf/ThymeleafViewRenderer.java
+++ b/src/main/java/uk/gov/register/thymeleaf/ThymeleafViewRenderer.java
@@ -41,7 +41,7 @@ public class ThymeleafViewRenderer implements ViewRenderer {
 
         templateResolver.setTemplateMode(templateMode);
         templateResolver.setCacheable(cacheable);
-        templateResolver.setCharacterEncoding("UTF-8");
+        templateResolver.setCharacterEncoding(StandardCharsets.UTF_8.name());
         engine = new TemplateEngine();
         engine.setTemplateResolver(templateResolver);
 


### PR DESCRIPTION
Using character encoding constant instead of specifying raw string
