### PR TITLE
Resolved Bug: /feed returns 404 when no records in database.

### DIFF
--- a/src/main/java/uk/gov/register/presentation/representations/ExtraMediaType.java
+++ b/src/main/java/uk/gov/register/presentation/representations/ExtraMediaType.java
@@ -3,14 +3,14 @@ package uk.gov.register.presentation.representations;
 import javax.ws.rs.core.MediaType;
 
 public class ExtraMediaType {
-    public static final String TEXT_HTML = "text/html; charset=utf-8";
+    public static final String TEXT_HTML = "text/html; charset=UTF-8";
 
-    public static final String TEXT_CSV = "text/csv; charset=utf-8";
-    public static final MediaType TEXT_CSV_TYPE = new MediaType("text", "csv", "utf-8");
-    public static final String TEXT_TSV = "text/tab-separated-values; charset=utf-8";
-    public static final MediaType TEXT_TSV_TYPE = new MediaType("text", "tab-separated-values", "utf-8");
-    public static final String TEXT_TTL = "text/turtle; charset=utf-8";
-    public static final MediaType TEXT_TTL_TYPE = new MediaType("text", "turtle", "utf-8");
-    public static final String TEXT_YAML = "text/yaml; charset=utf-8";
-    public static final MediaType TEXT_YAML_TYPE = new MediaType("text", "yaml", "utf-8");
+    public static final String TEXT_CSV = "text/csv; charset=UTF-8";
+    public static final MediaType TEXT_CSV_TYPE = new MediaType("text", "csv", "UTF-8");
+    public static final String TEXT_TSV = "text/tab-separated-values; charset=UTF-8";
+    public static final MediaType TEXT_TSV_TYPE = new MediaType("text", "tab-separated-values", "UTF-8");
+    public static final String TEXT_TTL = "text/turtle; charset=UTF-8";
+    public static final MediaType TEXT_TTL_TYPE = new MediaType("text", "turtle", "UTF-8");
+    public static final String TEXT_YAML = "text/yaml; charset=UTF-8";
+    public static final MediaType TEXT_YAML_TYPE = new MediaType("text", "yaml", "UTF-8");
 }

--- a/src/main/java/uk/gov/register/presentation/resource/Pagination.java
+++ b/src/main/java/uk/gov/register/presentation/resource/Pagination.java
@@ -23,7 +23,7 @@ public class Pagination {
             throw new BadRequestException();
         }
 
-        if ((this.pageIndex - 1) * this.pageSize >= totalEntries) {
+        if (pageIndex > 1 && ((pageIndex - 1) * pageSize) >= totalEntries) {
             throw new NotFoundException();
         }
     }

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -2,7 +2,7 @@
 
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml">
 <head th:fragment="head">
-    <meta charset="utf-8"/>
+    <meta charset="UTF-8"/>
     <meta name="mobile-web-app-capable" content="yes"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <link rel="icon" href="/assets/images/icon.png"/>

--- a/src/test/java/uk/gov/register/presentation/functional/CurrentResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/CurrentResourceFunctionalTest.java
@@ -1,7 +1,6 @@
 package uk.gov.register.presentation.functional;
 
 import com.google.common.collect.ImmutableList;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -9,15 +8,11 @@ import uk.gov.register.presentation.representations.DBSupport;
 
 import javax.ws.rs.core.Response;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class DataResourceFunctionalTest extends FunctionalTestBase {
+public class CurrentResourceFunctionalTest extends FunctionalTestBase {
     @BeforeClass
     public static void publishTestMessages() {
         DBSupport.publishMessages(ImmutableList.of(
@@ -48,23 +43,6 @@ public class DataResourceFunctionalTest extends FunctionalTestBase {
         assertThat(response.getStatus(), equalTo(301));
         assertThat(response.getHeaderString("Location"), equalTo("http://address.beta.openregister.org/current.json"));
 
-    }
-
-    @Test
-    public void latest_movedPermanentlyToFeedSoReturns301() throws InterruptedException, IOException {
-        Response response = getRequest("/latest.json");
-
-        assertThat(response.getStatus(), equalTo(301));
-        assertThat(response.getHeaderString("Location"), equalTo("http://address.beta.openregister.org/feed.json"));
-
-    }
-
-    private Map<String, String> createRelToLinkMap(Response response) {
-        String link = response.getHeaderString("Link");
-        return StringUtils.isNotEmpty(link) ? Stream.of(link.split(","))
-                .map(h -> h.split(";"))
-                .collect(Collectors.toMap(h -> h[1].trim().replaceAll("rel=\"([a-z]+)\"", "$1"), h -> h[0].trim().replaceAll("<([^>]+)>", "$1")))
-                : Collections.emptyMap();
     }
 }
 

--- a/src/test/java/uk/gov/register/presentation/functional/FeedResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/FeedResourceFunctionalTest.java
@@ -1,0 +1,29 @@
+package uk.gov.register.presentation.functional;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.junit.Test;
+
+import javax.ws.rs.core.Response;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class FeedResourceFunctionalTest extends FunctionalTestBase {
+    @Test
+    public void feed_returnsEmptyResultJsonWhenNoEntryIsAvailable() {
+        Response response = getRequest("/feed.json");
+        assertThat(response.getStatus(), equalTo(200));
+        assertThat(response.readEntity(ArrayNode.class).size(), equalTo(0));
+    }
+
+    @Test
+    public void latest_movedPermanentlyToFeedSoReturns301() throws InterruptedException, IOException {
+        Response response = getRequest("/latest.json");
+
+        assertThat(response.getStatus(), equalTo(301));
+        assertThat(response.getHeaderString("Location"), equalTo("http://address.beta.openregister.org/feed.json"));
+
+    }
+}

--- a/src/test/java/uk/gov/register/presentation/functional/RepresentationsTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/RepresentationsTest.java
@@ -37,10 +37,10 @@ public class RepresentationsTest extends FunctionalTestBase {
     @Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
-                {"csv", "text/csv;charset=utf-8", fixture("fixtures/single.csv"), fixture("fixtures/list.csv")},
-                {"tsv", "text/tab-separated-values;charset=utf-8", fixture("fixtures/single.tsv"), fixture("fixtures/list.tsv")},
-                {"ttl", "text/turtle;charset=utf-8", fixture("fixtures/single.ttl"), fixture("fixtures/list.ttl")},
-                {"yaml", "text/yaml;charset=utf-8", fixture("fixtures/single.yaml"), fixture("fixtures/list.yaml")}
+                {"csv", "text/csv;charset=UTF-8", fixture("fixtures/single.csv"), fixture("fixtures/list.csv")},
+                {"tsv", "text/tab-separated-values;charset=UTF-8", fixture("fixtures/single.tsv"), fixture("fixtures/list.tsv")},
+                {"ttl", "text/turtle;charset=UTF-8", fixture("fixtures/single.ttl"), fixture("fixtures/list.ttl")},
+                {"yaml", "text/yaml;charset=UTF-8", fixture("fixtures/single.yaml"), fixture("fixtures/list.yaml")}
         });
     }
 

--- a/src/test/java/uk/gov/register/presentation/resource/PaginationTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/PaginationTest.java
@@ -31,6 +31,10 @@ public class PaginationTest {
         new Pagination("/feed", Optional.of(-1l), Optional.of(1l), 10);
     }
 
+    @Test(expected = NotFoundException.class)
+    public void construct_throwsNotFoundException_whenNoMoreEntriesForGivenPageSizeAndPageIndexValues() {
+        new Pagination("/feed", Optional.of(2l), Optional.of(10l), 10);
+    }
 
     @Test
     public void offset_returnsTheNumberWhichOffsetsTheTotalEntriesBasedOnPageSize() {
@@ -85,10 +89,5 @@ public class PaginationTest {
     public void getPreviousPageLink_returnsTheLinkForPreviousPage() {
         Pagination pagination = new Pagination("/feed", Optional.of(2l), Optional.of(10l), 11);
         assertThat(pagination.getPreviousPageLink(), equalTo("/feed?pageIndex=1&pageSize=10"));
-    }
-
-    @Test(expected = NotFoundException.class)
-    public void construct_throwsNotFoundException_whenNoMoreEntriesForGivenPageSizeAndPageIndexValues() {
-        new Pagination("/feed", Optional.of(2l), Optional.of(10l), 10);
     }
 }


### PR DESCRIPTION
There was a check in Pagination class constructor which verifies that entries exist for given page number and size. If there is no entry for the given request parameters We throw NotFoundException. This check was causing 404 on /feed when you browse first page and there is no entries in database. In this case we should not throw 404 but render the page with zero entries.
The change in constructor confirms that the check is made only when the request is for a page number 2 or more. Now skipping the check for first page request.
There was a functional test failing because of comparision failure of utf-8 v/s UTF-8. So capitalized utf-8 to UTF-8 everywhere to resolve confusion in tests.
