### PR TITLE
Renamed the deployment group to match it with the preview environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,6 @@ deploy:
   key: presentation-$TRAVIS_BRANCH-$TRAVIS_BUILD_NUMBER-$TRAVIS_COMMIT.zip
   bundle_type: zip
   application: presentation-app
-  deployment_group: preview-presentation
+  deployment_group: preview
   region: eu-west-1
   on: *2


### PR DESCRIPTION
having a deployment group same as environment name helps automating of register creation
