### PR TITLE
Render total records on home page

### DIFF
--- a/src/main/java/uk/gov/register/presentation/dao/RecentEntryIndexQueryDAO.java
+++ b/src/main/java/uk/gov/register/presentation/dao/RecentEntryIndexQueryDAO.java
@@ -31,9 +31,15 @@ public interface RecentEntryIndexQueryDAO {
     @SingleValueResult(DbEntry.class)
     Optional<DbEntry> findBySerial(@Bind("serial") long serial);
 
-    @SqlQuery("SELECT SERIAL_NUMBER,ENTRY FROM ORDERED_ENTRY_INDEX WHERE SERIAL_NUMBER IN(SELECT SERIAL_NUMBER FROM CURRENT_KEYS ORDER BY SERIAL_NUMBER DESC LIMIT :limit) ORDER BY SERIAL_NUMBER DESC")
+    @SqlQuery("SELECT serial_number,entry FROM ordered_entry_index " +
+            "WHERE serial_number IN(" +
+            "SELECT serial_number FROM current_keys ORDER BY serial_number DESC LIMIT :limit" +
+            ") ORDER BY serial_number DESC")
     List<DbEntry> getLatestEntriesOfRecords(@Bind("limit") long maxNumberToFetch);
 
-    @SqlQuery("SELECT COUNT FROM REGISTER_ENTRIES_COUNT")
+    @SqlQuery("SELECT COUNT FROM register_entries_count")
     int getTotalEntriesCount();
+
+    @SqlQuery("SELECT COUNT FROM total_records")
+    int getTotalRecords();
 }

--- a/src/main/java/uk/gov/register/presentation/resource/HomePageResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/HomePageResource.java
@@ -1,6 +1,7 @@
 package uk.gov.register.presentation.resource;
 
 import io.dropwizard.views.View;
+import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
 import uk.gov.register.presentation.representations.ExtraMediaType;
 import uk.gov.register.presentation.view.ViewFactory;
 
@@ -13,16 +14,18 @@ import javax.ws.rs.core.MediaType;
 @Path("/")
 public class HomePageResource {
     private final ViewFactory viewFactory;
+    private final RecentEntryIndexQueryDAO recentEntryIndexQueryDAO;
 
     @Inject
-    public HomePageResource(ViewFactory viewFactory) {
+    public HomePageResource(ViewFactory viewFactory, RecentEntryIndexQueryDAO recentEntryIndexQueryDAO) {
         this.viewFactory = viewFactory;
+        this.recentEntryIndexQueryDAO = recentEntryIndexQueryDAO;
     }
 
     @GET
     @Produces({ExtraMediaType.TEXT_HTML})
     public View home() {
-        return viewFactory.homePageView();
+        return viewFactory.homePageView(recentEntryIndexQueryDAO.getTotalRecords());
     }
 
     @GET

--- a/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
+++ b/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
@@ -4,6 +4,7 @@ import org.jvnet.hk2.annotations.Service;
 import uk.gov.register.presentation.DbEntry;
 import uk.gov.register.presentation.EntryConverter;
 import uk.gov.register.presentation.config.PublicBodiesConfiguration;
+import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
 import uk.gov.register.presentation.resource.Pagination;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.register.thymeleaf.HomePageView;
@@ -18,12 +19,15 @@ public class ViewFactory {
     private final RequestContext requestContext;
     private final EntryConverter entryConverter;
     private final PublicBodiesConfiguration publicBodiesConfiguration;
+    private final RecentEntryIndexQueryDAO recentEntryIndexQueryDAO;
+
 
     @Inject
-    public ViewFactory(RequestContext requestContext, EntryConverter entryConverter, PublicBodiesConfiguration publicBodiesConfiguration) {
+    public ViewFactory(RequestContext requestContext, EntryConverter entryConverter, PublicBodiesConfiguration publicBodiesConfiguration, RecentEntryIndexQueryDAO recentEntryIndexQueryDAO) {
         this.requestContext = requestContext;
         this.entryConverter = entryConverter;
         this.publicBodiesConfiguration = publicBodiesConfiguration;
+        this.recentEntryIndexQueryDAO = recentEntryIndexQueryDAO;
     }
 
     public SingleEntryView getSingleEntryView(DbEntry dbEntry) {
@@ -55,7 +59,7 @@ public class ViewFactory {
     }
 
     public HomePageView homePageView() {
-        return new HomePageView(publicBodiesConfiguration, requestContext);
+        return new HomePageView(publicBodiesConfiguration, requestContext, recentEntryIndexQueryDAO);
     }
 
 }

--- a/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
+++ b/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
@@ -4,7 +4,6 @@ import org.jvnet.hk2.annotations.Service;
 import uk.gov.register.presentation.DbEntry;
 import uk.gov.register.presentation.EntryConverter;
 import uk.gov.register.presentation.config.PublicBodiesConfiguration;
-import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
 import uk.gov.register.presentation.resource.Pagination;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.register.thymeleaf.HomePageView;
@@ -19,15 +18,12 @@ public class ViewFactory {
     private final RequestContext requestContext;
     private final EntryConverter entryConverter;
     private final PublicBodiesConfiguration publicBodiesConfiguration;
-    private final RecentEntryIndexQueryDAO recentEntryIndexQueryDAO;
-
 
     @Inject
-    public ViewFactory(RequestContext requestContext, EntryConverter entryConverter, PublicBodiesConfiguration publicBodiesConfiguration, RecentEntryIndexQueryDAO recentEntryIndexQueryDAO) {
+    public ViewFactory(RequestContext requestContext, EntryConverter entryConverter, PublicBodiesConfiguration publicBodiesConfiguration) {
         this.requestContext = requestContext;
         this.entryConverter = entryConverter;
         this.publicBodiesConfiguration = publicBodiesConfiguration;
-        this.recentEntryIndexQueryDAO = recentEntryIndexQueryDAO;
     }
 
     public SingleEntryView getSingleEntryView(DbEntry dbEntry) {
@@ -58,8 +54,8 @@ public class ViewFactory {
         return new ThymeleafView(requestContext, templateName);
     }
 
-    public HomePageView homePageView() {
-        return new HomePageView(publicBodiesConfiguration, requestContext, recentEntryIndexQueryDAO);
+    public HomePageView homePageView(int totalRecords) {
+        return new HomePageView(publicBodiesConfiguration, requestContext, totalRecords);
     }
 
 }

--- a/src/main/java/uk/gov/register/thymeleaf/HomePageView.java
+++ b/src/main/java/uk/gov/register/thymeleaf/HomePageView.java
@@ -3,18 +3,17 @@ package uk.gov.register.thymeleaf;
 import org.markdownj.MarkdownProcessor;
 import uk.gov.register.presentation.config.PublicBodiesConfiguration;
 import uk.gov.register.presentation.config.PublicBody;
-import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
 import uk.gov.register.presentation.resource.RequestContext;
 
 public class HomePageView extends ThymeleafView {
     private final PublicBodiesConfiguration publicBodiesConfiguration;
-    private final RecentEntryIndexQueryDAO recentEntryIndexQueryDAO;
+    private final int totalRecords;
     private final MarkdownProcessor markdownProcessor = new MarkdownProcessor();
 
-    public HomePageView(PublicBodiesConfiguration publicBodiesConfiguration, RequestContext requestContext, RecentEntryIndexQueryDAO recentEntryIndexQueryDAO) {
+    public HomePageView(PublicBodiesConfiguration publicBodiesConfiguration, RequestContext requestContext, int totalRecords) {
         super(requestContext, "home.html");
         this.publicBodiesConfiguration = publicBodiesConfiguration;
-        this.recentEntryIndexQueryDAO = recentEntryIndexQueryDAO;
+        this.totalRecords = totalRecords;
     }
 
     @SuppressWarnings("unused, used from template")
@@ -29,7 +28,6 @@ public class HomePageView extends ThymeleafView {
 
     @SuppressWarnings("unused, used from template")
     public int getTotalRecords(){
-        return recentEntryIndexQueryDAO.getTotalRecords();
+        return totalRecords;
     }
-
 }

--- a/src/main/java/uk/gov/register/thymeleaf/HomePageView.java
+++ b/src/main/java/uk/gov/register/thymeleaf/HomePageView.java
@@ -3,15 +3,18 @@ package uk.gov.register.thymeleaf;
 import org.markdownj.MarkdownProcessor;
 import uk.gov.register.presentation.config.PublicBodiesConfiguration;
 import uk.gov.register.presentation.config.PublicBody;
+import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
 import uk.gov.register.presentation.resource.RequestContext;
 
 public class HomePageView extends ThymeleafView {
     private final PublicBodiesConfiguration publicBodiesConfiguration;
+    private final RecentEntryIndexQueryDAO recentEntryIndexQueryDAO;
     private final MarkdownProcessor markdownProcessor = new MarkdownProcessor();
 
-    public HomePageView(PublicBodiesConfiguration publicBodiesConfiguration, RequestContext requestContext) {
+    public HomePageView(PublicBodiesConfiguration publicBodiesConfiguration, RequestContext requestContext, RecentEntryIndexQueryDAO recentEntryIndexQueryDAO) {
         super(requestContext, "home.html");
         this.publicBodiesConfiguration = publicBodiesConfiguration;
+        this.recentEntryIndexQueryDAO = recentEntryIndexQueryDAO;
     }
 
     @SuppressWarnings("unused, used from template")
@@ -23,4 +26,10 @@ public class HomePageView extends ThymeleafView {
     public String getRegisterText() {
         return markdownProcessor.markdown(getRegister().getText());
     }
+
+    @SuppressWarnings("unused, used from template")
+    public int getTotalRecords(){
+        return recentEntryIndexQueryDAO.getTotalRecords();
+    }
+
 }

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -19,7 +19,7 @@
 
             <dl class="primary-metadata">
                 <dt>Total records:</dt>
-                <dd><a href="/current">Total records</a></dd>
+                <dd><a href="/current" th:text="${totalRecords}">Total records</a></dd>
                 <dt>Last updated:</dt>
                 <dd><a href="/feed">Last updated</a></dd>
             </dl>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -18,8 +18,8 @@
             </div>
 
             <dl class="primary-metadata">
-                <dt>Total entries:</dt>
-                <dd><a href="/current">Total entries</a></dd>
+                <dt>Total records:</dt>
+                <dd><a href="/current">Total records</a></dd>
                 <dt>Last updated:</dt>
                 <dd><a href="/feed">Last updated</a></dd>
             </dl>

--- a/src/test/java/uk/gov/register/thymeleaf/HomePageViewTest.java
+++ b/src/test/java/uk/gov/register/thymeleaf/HomePageViewTest.java
@@ -20,7 +20,7 @@ public class HomePageViewTest {
 
     @Test
     public void getRegisterText_rendersRegisterTextAsMarkdown() throws Exception {
-        HomePageView homePageView = new HomePageView(null, mockRequestContext, null);
+        HomePageView homePageView = new HomePageView(null, mockRequestContext, 1);
 
         String registerText = "foo *bar* [baz](/quux)";
         when(mockRequestContext.getRegister()).thenReturn(new Register("", Sets.newSet(), "", "", registerText));

--- a/src/test/java/uk/gov/register/thymeleaf/HomePageViewTest.java
+++ b/src/test/java/uk/gov/register/thymeleaf/HomePageViewTest.java
@@ -20,7 +20,7 @@ public class HomePageViewTest {
 
     @Test
     public void getRegisterText_rendersRegisterTextAsMarkdown() throws Exception {
-        HomePageView homePageView = new HomePageView(null, mockRequestContext);
+        HomePageView homePageView = new HomePageView(null, mockRequestContext, null);
 
         String registerText = "foo *bar* [baz](/quux)";
         when(mockRequestContext.getRegister()).thenReturn(new Register("", Sets.newSet(), "", "", registerText));


### PR DESCRIPTION
NOTE: Do not merge this PR before successful merge of PR https://github.com/openregister/indexer/pull/25 in indexer repo. This is required because the total_records table is created by indexer app.

This PR renders total records on register home page, Using total_records table to fetch the total records in register.
