### PR TITLE
Rendering registers lastupdated time on home page

### DIFF
--- a/src/main/java/uk/gov/register/presentation/dao/RecentEntryIndexQueryDAO.java
+++ b/src/main/java/uk/gov/register/presentation/dao/RecentEntryIndexQueryDAO.java
@@ -7,6 +7,7 @@ import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
 import uk.gov.register.presentation.DbEntry;
 import uk.gov.register.presentation.mapper.EntryMapper;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -37,9 +38,13 @@ public interface RecentEntryIndexQueryDAO {
             ") ORDER BY serial_number DESC")
     List<DbEntry> getLatestEntriesOfRecords(@Bind("limit") long maxNumberToFetch, @Bind("offset") long offset);
 
-    @SqlQuery("SELECT COUNT FROM total_entries")
+    @SqlQuery("SELECT count FROM total_entries")
     int getTotalEntriesCount();
 
-    @SqlQuery("SELECT COUNT FROM total_records")
+    @SqlQuery("SELECT count FROM total_records")
     int getTotalRecords();
+
+    @SqlQuery("SELECT last_updated FROM total_entries")
+    LocalDateTime getLastUpdatedTime();
+
 }

--- a/src/main/java/uk/gov/register/presentation/resource/HomePageResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/HomePageResource.java
@@ -25,7 +25,7 @@ public class HomePageResource {
     @GET
     @Produces({ExtraMediaType.TEXT_HTML})
     public View home() {
-        return viewFactory.homePageView(recentEntryIndexQueryDAO.getTotalRecords());
+        return viewFactory.homePageView(recentEntryIndexQueryDAO.getTotalRecords(), recentEntryIndexQueryDAO.getLastUpdatedTime());
     }
 
     @GET

--- a/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
+++ b/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
@@ -10,6 +10,7 @@ import uk.gov.register.thymeleaf.HomePageView;
 import uk.gov.register.thymeleaf.ThymeleafView;
 
 import javax.inject.Inject;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -54,8 +55,8 @@ public class ViewFactory {
         return new ThymeleafView(requestContext, templateName);
     }
 
-    public HomePageView homePageView(int totalRecords) {
-        return new HomePageView(publicBodiesConfiguration, requestContext, totalRecords);
+    public HomePageView homePageView(int totalRecords, LocalDateTime lastUpdated) {
+        return new HomePageView(publicBodiesConfiguration, requestContext, totalRecords, lastUpdated);
     }
 
 }

--- a/src/main/java/uk/gov/register/thymeleaf/HomePageView.java
+++ b/src/main/java/uk/gov/register/thymeleaf/HomePageView.java
@@ -5,15 +5,28 @@ import uk.gov.register.presentation.config.PublicBodiesConfiguration;
 import uk.gov.register.presentation.config.PublicBody;
 import uk.gov.register.presentation.resource.RequestContext;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
 public class HomePageView extends ThymeleafView {
+    private final static DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("dd/MM/YYYY HH:mm:ss");
+
     private final PublicBodiesConfiguration publicBodiesConfiguration;
-    private final int totalRecords;
     private final MarkdownProcessor markdownProcessor = new MarkdownProcessor();
 
-    public HomePageView(PublicBodiesConfiguration publicBodiesConfiguration, RequestContext requestContext, int totalRecords) {
+    private final LocalDateTime lastUpdated;
+    private final int totalRecords;
+
+    public HomePageView(
+            PublicBodiesConfiguration publicBodiesConfiguration,
+            RequestContext requestContext,
+            int totalRecords,
+            LocalDateTime lastUpdated
+    ) {
         super(requestContext, "home.html");
         this.publicBodiesConfiguration = publicBodiesConfiguration;
         this.totalRecords = totalRecords;
+        this.lastUpdated = lastUpdated;
     }
 
     @SuppressWarnings("unused, used from template")
@@ -29,5 +42,10 @@ public class HomePageView extends ThymeleafView {
     @SuppressWarnings("unused, used from template")
     public int getTotalRecords(){
         return totalRecords;
+    }
+
+    @SuppressWarnings("unused, used from template")
+    public String getLastUpdatedTime(){
+        return DATE_TIME_FORMATTER.format(lastUpdated);
     }
 }

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -21,7 +21,7 @@
                 <dt>Total records:</dt>
                 <dd><a href="/current" th:text="${totalRecords}">Total records</a></dd>
                 <dt>Last updated:</dt>
-                <dd><a href="/feed">Last updated</a></dd>
+                <dd><a href="/feed" th:text="${lastUpdatedTime}">Last updated</a></dd>
             </dl>
         </div>
     </div>

--- a/src/test/java/uk/gov/register/thymeleaf/HomePageViewTest.java
+++ b/src/test/java/uk/gov/register/thymeleaf/HomePageViewTest.java
@@ -8,6 +8,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.register.presentation.config.Register;
 import uk.gov.register.presentation.resource.RequestContext;
 
+import java.time.LocalDateTime;
+
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
@@ -20,7 +22,7 @@ public class HomePageViewTest {
 
     @Test
     public void getRegisterText_rendersRegisterTextAsMarkdown() throws Exception {
-        HomePageView homePageView = new HomePageView(null, mockRequestContext, 1);
+        HomePageView homePageView = new HomePageView(null, mockRequestContext, 1, null);
 
         String registerText = "foo *bar* [baz](/quux)";
         when(mockRequestContext.getRegister()).thenReturn(new Register("", Sets.newSet(), "", "", registerText));
@@ -28,5 +30,14 @@ public class HomePageViewTest {
         String result = homePageView.getRegisterText();
 
         assertThat(result, equalTo("<p>foo <em>bar</em> <a href=\"/quux\">baz</a></p>\n"));
+    }
+
+    @Test
+    public void getLastUpdatedTime_formatsTheLocalDateTimeToUKDateTimeFormat() {
+        LocalDateTime localDateTime = LocalDateTime.of(2015, 9, 11, 13, 17, 59, 543);
+
+        HomePageView homePageView = new HomePageView(null, mockRequestContext, 1, localDateTime);
+
+        assertThat(homePageView.getLastUpdatedTime(), equalTo("11/09/2015 13:17:59"));
     }
 }


### PR DESCRIPTION
total_entries table has a column which contains the time when the ordered_entry_index table was last updated. rendering this time on register home page.
