### PR TITLE
use new GIN index for history queries

### DIFF
--- a/src/main/java/uk/gov/register/presentation/dao/RecentEntryIndexQueryDAO.java
+++ b/src/main/java/uk/gov/register/presentation/dao/RecentEntryIndexQueryDAO.java
@@ -1,5 +1,10 @@
 package uk.gov.register.presentation.dao;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import io.dropwizard.jackson.Jackson;
+import org.postgresql.util.PGobject;
 import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
@@ -7,44 +12,58 @@ import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
 import uk.gov.register.presentation.DbEntry;
 import uk.gov.register.presentation.mapper.EntryMapper;
 
+import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 @RegisterMapper(EntryMapper.class)
-public interface RecentEntryIndexQueryDAO {
+public abstract class RecentEntryIndexQueryDAO {
+
+    private final ObjectMapper objectMapper = Jackson.newObjectMapper();
 
     @SqlQuery("SELECT serial_number,entry FROM ordered_entry_index ORDER BY serial_number DESC LIMIT :limit OFFSET :offset")
-    List<DbEntry> getAllEntries(@Bind("limit") long maxNumberToFetch, @Bind("offset") long offset);
+    public abstract List<DbEntry> getAllEntries(@Bind("limit") long maxNumberToFetch, @Bind("offset") long offset);
 
     @SqlQuery("SELECT serial_number,entry FROM ordered_entry_index WHERE serial_number = (SELECT serial_number FROM CURRENT_KEYS WHERE key = :key)")
     @SingleValueResult(DbEntry.class)
-    Optional<DbEntry> findByPrimaryKey(@Bind("key") String key);
+    public abstract Optional<DbEntry> findByPrimaryKey(@Bind("key") String key);
 
-    @SqlQuery("SELECT serial_number,entry FROM ordered_entry_index WHERE (entry #>> ARRAY['entry',:key]) = :value ORDER BY serial_number DESC")
-    List<DbEntry> findAllByKeyValue(@Bind("key") String key, @Bind("value") String value);
+    @SqlQuery("SELECT serial_number,entry FROM ordered_entry_index WHERE (entry @> :content) ORDER BY serial_number DESC")
+    public abstract List<DbEntry> findAllByJsonContent(@Bind("content") PGobject json);
+
+    public List<DbEntry> findAllByKeyValue(String key, String value) throws Exception {
+        Object entry = ImmutableMap.of("entry", ImmutableMap.of(key, value));
+        return findAllByJsonContent(writePGObject(entry));
+    }
 
     @SqlQuery("SELECT serial_number,entry FROM ordered_entry_index WHERE (entry #>> ARRAY['hash']) = :hash")
     @SingleValueResult(DbEntry.class)
-    Optional<DbEntry> findByHash(@Bind("hash") String hash);
+    public abstract Optional<DbEntry> findByHash(@Bind("hash") String hash);
 
     @SqlQuery("SELECT serial_number,entry from ordered_entry_index where serial_number = :serial")
     @SingleValueResult(DbEntry.class)
-    Optional<DbEntry> findBySerial(@Bind("serial") long serial);
+    public abstract Optional<DbEntry> findBySerial(@Bind("serial") long serial);
 
     @SqlQuery("SELECT serial_number,entry FROM ordered_entry_index " +
             "WHERE serial_number IN(" +
             "SELECT serial_number FROM current_keys ORDER BY serial_number DESC LIMIT :limit OFFSET :offset" +
             ") ORDER BY serial_number DESC")
-    List<DbEntry> getLatestEntriesOfRecords(@Bind("limit") long maxNumberToFetch, @Bind("offset") long offset);
+    public abstract List<DbEntry> getLatestEntriesOfRecords(@Bind("limit") long maxNumberToFetch, @Bind("offset") long offset);
 
     @SqlQuery("SELECT count FROM total_entries")
-    int getTotalEntriesCount();
+    public abstract int getTotalEntriesCount();
 
     @SqlQuery("SELECT count FROM total_records")
-    int getTotalRecords();
+    public abstract int getTotalRecords();
 
     @SqlQuery("SELECT last_updated FROM total_entries")
-    LocalDateTime getLastUpdatedTime();
+    public abstract LocalDateTime getLastUpdatedTime();
 
+    private PGobject writePGObject(Object value) throws JsonProcessingException, SQLException {
+        PGobject json = new PGobject();
+        json.setType("jsonb");
+        json.setValue(objectMapper.writeValueAsString(value));
+        return json;
+    }
 }

--- a/src/main/java/uk/gov/register/presentation/resource/HistoryResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/HistoryResource.java
@@ -30,7 +30,7 @@ public class HistoryResource {
     @GET
     @Path("/{primaryKey}/{primaryKeyValue}/history")
     @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON})
-    public ListVersionView history(@PathParam("primaryKey") String key, @PathParam("primaryKeyValue") String value) {
+    public ListVersionView history(@PathParam("primaryKey") String key, @PathParam("primaryKeyValue") String value) throws Exception {
         String registerPrimaryKey = requestContext.getRegisterPrimaryKey();
         if (key.equals(registerPrimaryKey)) {
             return new ListVersionView(requestContext, queryDAO.findAllByKeyValue(key, value).stream().map(r -> new Version(r.getSerialNumber(), r.getContent().getHash())).collect(Collectors.toList()));

--- a/src/test/java/uk/gov/register/presentation/resource/HistoryResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/HistoryResourceTest.java
@@ -13,7 +13,6 @@ import uk.gov.register.presentation.config.RegistersConfiguration;
 import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
 
 import javax.ws.rs.NotFoundException;
-
 import java.util.Arrays;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -41,7 +40,7 @@ public class HistoryResourceTest {
     }
 
     @Test
-    public void history_throwsNotFoundExceptionForNonPrimaryKeyRequests() {
+    public void history_throwsNotFoundExceptionForNonPrimaryKeyRequests() throws Exception {
         try {
             resource.history("someOtherKey", "value");
             fail("Must fail");


### PR DESCRIPTION
The new index doesn't support the `#>>` operator but does support the `@>`
operator.  This rewrites our queries to be able to take advantage of the
GIN index and avoid a full table scan.
