### PR TITLE
Set appropriate filename for downloads

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ configurations {
     compile.exclude module: 'slf4j-simple' // dropwizard uses logback, not slf4j-simple
 }
 dependencies {
-    compile dropwizard, markdown, postgresClient, thymeleaf
+    compile dropwizard, jerseyMedia, markdown, postgresClient, thymeleaf
 
     testCompile dropwizardTest, junit, jsonAssert
 }

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -1,6 +1,7 @@
 ext {
     dropwizard_version = '0.8.2'
     dropwizard_java8_version = '0.8.0-1'
+    jersey_version = '2.19' // based on dropwizard 0.8.2's jersey version
 
     dropwizard = [
             "io.dropwizard:dropwizard-core:${dropwizard_version}",
@@ -10,6 +11,8 @@ ext {
             "io.dropwizard:dropwizard-views:${dropwizard_version}",
             "io.dropwizard:dropwizard-assets:${dropwizard_version}"
     ]
+
+    jerseyMedia = "org.glassfish.jersey.media:jersey-media-multipart:${jersey_version}"
 
     markdown = 'org.markdownj:markdownj-core:0.4'
 

--- a/src/main/java/uk/gov/register/presentation/resource/DataResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/DataResource.java
@@ -59,22 +59,8 @@ public class DataResource {
 
         setNextAndPreviousPageLinkHeader(pagination);
 
-        getFileExtension().ifPresent(this::addContentDispositionHeader);
+        getFileExtension().ifPresent(ext -> addContentDispositionHeader(requestContext.getRegisterPrimaryKey() + "-entries." + ext));
         return viewFactory.getEntryFeedView(queryDAO.getAllEntries(pagination.pageSize(), pagination.offset()), pagination);
-    }
-
-    private void addContentDispositionHeader(String ext) {
-        ContentDisposition contentDisposition = ContentDisposition.type("attachment").fileName(requestContext.getRegisterPrimaryKey() + "-entries." + ext).build();
-        requestContext.getHttpServletResponse().addHeader(HttpHeaders.CONTENT_DISPOSITION, contentDisposition.toString());
-    }
-
-    private Optional<String> getFileExtension() {
-        String requestURI = requestContext.getHttpServletRequest().getRequestURI();
-        if (requestURI.lastIndexOf('.') == -1) {
-            return Optional.empty();
-        }
-        String[] tokens = requestURI.split("\\.");
-        return Optional.of(tokens[tokens.length-1]);
     }
 
     @GET
@@ -85,6 +71,7 @@ public class DataResource {
 
         setNextAndPreviousPageLinkHeader(pagination);
 
+        getFileExtension().ifPresent(ext -> addContentDispositionHeader(requestContext.getRegisterPrimaryKey() + "-records." + ext));
         return viewFactory.getRecordEntriesView(queryDAO.getLatestEntriesOfRecords(pagination.pageSize(), pagination.offset()), pagination);
     }
 
@@ -100,6 +87,20 @@ public class DataResource {
     @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
     public Response current(@QueryParam("pageIndex") Optional<Long> pageIndex, @QueryParam("pageSize") Optional<Long> pageSize) {
         return create301Response("/records", pageIndex, pageSize);
+    }
+
+    private Optional<String> getFileExtension() {
+        String requestURI = requestContext.getHttpServletRequest().getRequestURI();
+        if (requestURI.lastIndexOf('.') == -1) {
+            return Optional.empty();
+        }
+        String[] tokens = requestURI.split("\\.");
+        return Optional.of(tokens[tokens.length-1]);
+    }
+
+    private void addContentDispositionHeader(String fileName) {
+        ContentDisposition contentDisposition = ContentDisposition.type("attachment").fileName(fileName).build();
+        requestContext.getHttpServletResponse().addHeader(HttpHeaders.CONTENT_DISPOSITION, contentDisposition.toString());
     }
 
     private void setNextAndPreviousPageLinkHeader(Pagination pagination) {

--- a/src/test/java/uk/gov/register/presentation/functional/EntriesResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/EntriesResourceFunctionalTest.java
@@ -3,10 +3,12 @@ package uk.gov.register.presentation.functional;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.junit.Test;
 
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 
 import java.io.IOException;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -16,6 +18,13 @@ public class EntriesResourceFunctionalTest extends FunctionalTestBase {
         Response response = getRequest("/entries.json");
         assertThat(response.getStatus(), equalTo(200));
         assertThat(response.readEntity(ArrayNode.class).size(), equalTo(0));
+    }
+
+    @Test
+    public void entries_setsAppropriateFilenameForDownload() {
+        Response response = getRequest("address", "/entries.json");
+        assertThat(response.getStatus(), equalTo(200));
+        assertThat(response.getHeaderString(HttpHeaders.CONTENT_DISPOSITION), containsString("filename=\"address-entries.json\""));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/presentation/functional/EntriesResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/EntriesResourceFunctionalTest.java
@@ -12,14 +12,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class EntriesResourceFunctionalTest extends FunctionalTestBase {
     @Test
-    public void feed_returnsEmptyResultJsonWhenNoEntryIsAvailable() {
+    public void entries_returnsEmptyResultJsonWhenNoEntryIsAvailable() {
         Response response = getRequest("/entries.json");
         assertThat(response.getStatus(), equalTo(200));
         assertThat(response.readEntity(ArrayNode.class).size(), equalTo(0));
     }
 
     @Test
-    public void latest_movedPermanentlyToFeedSoReturns301() throws InterruptedException, IOException {
+    public void feed_movedPermanentlyToFeedSoReturns301() throws InterruptedException, IOException {
         Response response = getRequest("/feed.json");
 
         assertThat(response.getStatus(), equalTo(301));

--- a/src/test/java/uk/gov/register/presentation/functional/RecordsResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/RecordsResourceFunctionalTest.java
@@ -6,9 +6,11 @@ import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import uk.gov.register.presentation.representations.DBSupport;
 
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -34,6 +36,13 @@ public class RecordsResourceFunctionalTest extends FunctionalTestBase {
                         "{\"serial-number\":1,\"hash\":\"hash1\",\"entry\":{\"name\":\"ellis\",\"address\":\"12345\"}}" +
                         "]"
                 , false);
+    }
+
+    @Test
+    public void records_setsAppropriateFilenameForDownload() {
+        Response response = getRequest("address", "/records.json");
+        assertThat(response.getStatus(), equalTo(200));
+        assertThat(response.getHeaderString(HttpHeaders.CONTENT_DISPOSITION), containsString("filename=\"address-records.json\""));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/presentation/resource/DataResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/DataResourceTest.java
@@ -46,7 +46,7 @@ public class DataResourceTest {
     }
 
     @Test
-    public void feedSupportsJsonCsvTsv() throws Exception {
+    public void entries_supportsJsonCsvTsv() throws Exception {
         Method feedMethod = DataResource.class.getDeclaredMethod("entries", Optional.class, Optional.class);
         List<String> declaredMediaTypes = asList(feedMethod.getAnnotation(Produces.class).value());
         assertThat(declaredMediaTypes, hasItems(
@@ -59,7 +59,7 @@ public class DataResourceTest {
     }
 
     @Test
-    public void currentSupportsJsonCsvTsvHtmlAndTurtle() throws Exception {
+    public void records_supportsJsonCsvTsvHtmlAndTurtle() throws Exception {
         Method allMethod = DataResource.class.getDeclaredMethod("records", Optional.class, Optional.class);
         List<String> declaredMediaTypes = asList(allMethod.getAnnotation(Produces.class).value());
         assertThat(declaredMediaTypes, hasItems(


### PR DESCRIPTION
Set the Content-disposition header for /records and /entries.
