### PR TITLE
Add register fingerprint info to front page

### DIFF
--- a/src/main/resources/assets/css/main.css
+++ b/src/main/resources/assets/css/main.css
@@ -806,6 +806,36 @@ button:focus,
             text-align: right; } }
 
 /* Register styles */
+details {
+  display: block; }
+  details summary {
+    display: inline-block;
+    color: #005ea5;
+    cursor: pointer;
+    position: relative;
+    margin-bottom: em(5); }
+    details summary:hover {
+      color: #2e8aca; }
+    details summary:focus {
+      outline: 3px solid #ffbf47; }
+  details .summary {
+    text-decoration: underline; }
+  details .arrow {
+    margin-right: .35em;
+    font-style: normal; }
+
+.fingerprint-container {
+  margin: 35px 15px 15px 15px;
+  background-color: #f5f5f5;
+  padding: 25px; }
+
+.fingerprint {
+  font-family: monospace;
+  white-space: pre; }
+
+.fingerprint-explanation {
+  float: right; }
+
 body {
   font-family: "GDS-Logo", sans-serif; }
 
@@ -963,13 +993,12 @@ dd a {
 .technical-information {
   margin: 35px 15px 15px 15px;
   padding: 25px;
-  background-color: #F8F8F8;
+  background-color: #f5f5f5;
   border: 1px solid #BFC1C3; }
 
 .field-list ul {
   padding-left: 0;
-  margin-top: 0;
-  }
+  margin-top: 0; }
 
 .field-list li {
   font-family: monospace;

--- a/src/main/resources/assets/css/main.css
+++ b/src/main/resources/assets/css/main.css
@@ -825,7 +825,8 @@ details {
     font-style: normal; }
 
 .fingerprint-container {
-  margin: 35px 15px 15px 15px;
+  margin-top: 35px;
+  margin-bottom: 15px;
   background-color: #f5f5f5;
   padding: 25px; }
 
@@ -991,7 +992,8 @@ dd a {
       width: 66.66667%; } }
 
 .technical-information {
-  margin: 35px 15px 15px 15px;
+  margin-top: 35px;
+  margin-bottom: 15px;
   padding: 25px;
   background-color: #f5f5f5;
   border: 1px solid #BFC1C3; }

--- a/src/main/resources/assets/js/details.polyfill.js
+++ b/src/main/resources/assets/js/details.polyfill.js
@@ -1,0 +1,195 @@
+// originally copied from https://github.com/alphagov/govuk_elements
+
+// <details> polyfill
+// http://caniuse.com/#feat=details
+
+// FF Support for HTML5's <details> and <summary>
+// https://bugzilla.mozilla.org/show_bug.cgi?id=591737
+
+// http://www.sitepoint.com/fixing-the-details-element/
+
+(function () {
+  'use strict';
+
+  var NATIVE_DETAILS = typeof document.createElement('details').open === 'boolean';
+
+  // Add event construct for modern browsers or IE
+  // which fires the callback with a pre-converted target reference
+  function addEvent(node, type, callback) {
+    if (node.addEventListener) {
+      node.addEventListener(type, function (e) {
+        callback(e, e.target);
+      }, false);
+    } else if (node.attachEvent) {
+      node.attachEvent('on' + type, function (e) {
+        callback(e, e.srcElement);
+      });
+    }
+  }
+
+  // Handle cross-modal click events
+  function addClickEvent(node, callback) {
+    // Prevent space(32) from scrolling the page
+    addEvent(node, 'keypress', function (e, target) {
+      if (target.nodeName === 'SUMMARY') {
+        if (e.keyCode === 32) {
+          if (e.preventDefault) {
+            e.preventDefault();
+          } else {
+            e.returnValue = false;
+          }
+        }
+      }
+    });
+    // When the key comes up - check if it is enter(13) or space(32)
+    addEvent(node, 'keyup', function (e, target) {
+      if (e.keyCode === 13 || e.keyCode === 32) { callback(e, target); }
+    });
+    addEvent(node, 'mouseup', function (e, target) {
+      callback(e, target);
+    });
+  }
+
+  // Get the nearest ancestor element of a node that matches a given tag name
+  function getAncestor(node, match) {
+    do {
+      if (!node || node.nodeName.toLowerCase() === match) {
+        break;
+      }
+    } while (node = node.parentNode);
+
+    return node;
+  }
+
+  // Create a started flag so we can prevent the initialisation
+  // function firing from both DOMContentLoaded and window.onload
+  var started = false;
+
+  // Initialisation function
+  function addDetailsPolyfill(list) {
+
+    // If this has already happened, just return
+    // else set the flag so it doesn't happen again
+    if (started) {
+      return;
+    }
+    started = true;
+
+    // Get the collection of details elements, but if that's empty
+    // then we don't need to bother with the rest of the scripting
+    if ((list = document.getElementsByTagName('details')).length === 0) {
+      return;
+    }
+
+    // else iterate through them to apply their initial state
+    var n = list.length, i = 0;
+    for (i; i < n; i++) {
+      var details = list[i];
+
+      // Save shortcuts to the inner summary and content elements
+      details.__summary = details.getElementsByTagName('summary').item(0);
+      details.__content = details.getElementsByTagName('div').item(0);
+
+      // If the content doesn't have an ID, assign it one now
+      // which we'll need for the summary's aria-controls assignment
+      if (!details.__content.id) {
+        details.__content.id = 'details-content-' + i;
+      }
+
+      // Add ARIA role="group" to details
+      details.setAttribute('role', 'group');
+
+      // Add role=button to summary
+      details.__summary.setAttribute('role', 'button');
+
+      // Add aria-controls
+      details.__summary.setAttribute('aria-controls', details.__content.id);
+
+      // Set tabIndex so the summary is keyboard accessible for non-native elements
+      // http://www.saliences.com/browserBugs/tabIndex.html
+      if (!NATIVE_DETAILS) {
+        details.__summary.tabIndex = 0;
+      }
+
+      // Detect initial open state
+      var openAttr = details.getAttribute('open') !== null;
+      if (openAttr === true) {
+        details.__summary.setAttribute('aria-expanded', 'true');
+        details.__content.setAttribute('aria-hidden', 'false');
+      } else {
+        details.__summary.setAttribute('aria-expanded', 'false');
+        details.__content.setAttribute('aria-hidden', 'true');
+        if (!NATIVE_DETAILS) {
+          details.__content.style.display = 'none';
+        }
+      }
+
+      // Create a circular reference from the summary back to its
+      // parent details element, for convenience in the click handler
+      details.__summary.__details = details;
+
+      // If this is not a native implementation, create an arrow
+      // inside the summary
+      if (!NATIVE_DETAILS) {
+
+        var twisty = document.createElement('i');
+
+        if (openAttr === true) {
+          twisty.className = 'arrow arrow-open';
+          twisty.appendChild(document.createTextNode('\u25bc'));
+        } else {
+          twisty.className = 'arrow arrow-closed';
+          twisty.appendChild(document.createTextNode('\u25ba'));
+        }
+
+        details.__summary.__twisty = details.__summary.insertBefore(twisty, details.__summary.firstChild);
+        details.__summary.__twisty.setAttribute('aria-hidden', 'true');
+
+      }
+    }
+
+    // Define a statechange function that updates aria-expanded and style.display
+    // Also update the arrow position
+    function statechange(summary) {
+
+      var expanded = summary.__details.__summary.getAttribute('aria-expanded') === 'true';
+      var hidden = summary.__details.__content.getAttribute('aria-hidden') === 'true';
+
+      summary.__details.__summary.setAttribute('aria-expanded', (expanded ? 'false' : 'true'));
+      summary.__details.__content.setAttribute('aria-hidden', (hidden ? 'false' : 'true'));
+
+      if (!NATIVE_DETAILS) {
+        summary.__details.__content.style.display = (expanded ? 'none' : '');
+
+        var hasOpenAttr = summary.__details.getAttribute('open') !== null;
+        if (!hasOpenAttr) {
+          summary.__details.setAttribute('open', 'open');
+        } else {
+          summary.__details.removeAttribute('open');
+        }
+      }
+
+      if (summary.__twisty) {
+        summary.__twisty.firstChild.nodeValue = (expanded ? '\u25ba' : '\u25bc');
+        summary.__twisty.setAttribute('class', (expanded ? 'arrow arrow-closed' : 'arrow arrow-open'));
+      }
+
+      return true;
+    }
+
+    // Bind a click event to handle summary elements
+    addClickEvent(document, function(e, summary) {
+      if (!(summary = getAncestor(summary, 'summary'))) {
+        return true;
+      }
+      return statechange(summary);
+    });
+  }
+
+  // Bind two load events for modern and older browsers
+  // If the first one fires it will set a flag to block the second one
+  // but if it's not supported then the second one will fire
+  addEvent(document, 'DOMContentLoaded', addDetailsPolyfill);
+  addEvent(window, 'load', addDetailsPolyfill);
+
+})();

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -25,7 +25,6 @@
             </dl>
         </div>
     </div>
-    <div class="grid-row">
     <div class="technical-information">
     <div class="grid-row">
         <div class="column-two-thirds">
@@ -47,16 +46,15 @@
         <summary>Check the register fingerprint</summary>
         <div class="fingerprint-container">
             <span class="fingerprint-explanation"><a href="https://gdstechnology.blog.gov.uk/2015/10/13/guaranteeing-the-integrity-of-a-register/">See how the fingerprint works</a></span>
-            <span class="fingerprint">{
+            <pre class="fingerprint"><code>{
   "tree_size": 9803348,
   "timestamp": 1447421303202,
   "sha256_root_hash": "JATHxRF5gczvNPP1S1WuhD8jSx2bl+WoTt8bIE3YKvU=",
   "tree_head_signature":
   "BAMARzBFAiEAkKM3aRUBKhShdCyrGLdd8lYBV52FLrwqjHa5/YuzK7ECIFTlRmNuKLqbVQv0QS8nq0pAUwgbilKOR5piBAIC8LpS"
-}</span>
+}</code></pre>
         </div>
     </details>
-    </div>
 
     <p th:replace="copyright.html::copyright">Copyright text</p>
 

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -43,6 +43,19 @@
         </div>
     </div>    
     </div>
+    <details>
+        <summary>Check the register fingerprint</summary>
+        <div class="fingerprint-container">
+            <span class="fingerprint-explanation"><a href="https://gdstechnology.blog.gov.uk/2015/10/13/guaranteeing-the-integrity-of-a-register/">See how the fingerprint works</a></span>
+            <span class="fingerprint">{
+  "tree_size": 9803348,
+  "timestamp": 1447421303202,
+  "sha256_root_hash": "JATHxRF5gczvNPP1S1WuhD8jSx2bl+WoTt8bIE3YKvU=",
+  "tree_head_signature":
+  "BAMARzBFAiEAkKM3aRUBKhShdCyrGLdd8lYBV52FLrwqjHa5/YuzK7ECIFTlRmNuKLqbVQv0QS8nq0pAUwgbilKOR5piBAIC8LpS"
+}</span>
+        </div>
+    </details>
     </div>
 
     <p th:replace="copyright.html::copyright">Copyright text</p>

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -53,6 +53,7 @@
             </div>
         </div>
     </div>
+    <script type="text/javascript" src="assets/js/details.polyfill.js"/>
 </footer>
 
 </html>

--- a/src/main/sass/_details.scss
+++ b/src/main/sass/_details.scss
@@ -1,0 +1,34 @@
+// Details
+// ==========================================================================
+
+details {
+  display: block;
+
+  summary {
+    display: inline-block;
+    color: $govuk-blue;
+    cursor: pointer;
+    position: relative;
+    margin-bottom: em(5);
+
+    &:hover {
+      color: $link-hover-colour;
+    }
+
+    &:focus {
+      outline: 3px solid $focus-colour;
+    }
+  }
+
+  // Underline only summary text (not the arrow)
+  .summary {
+    text-decoration: underline;
+  }
+
+  // Match fallback arrow spacing with -webkit default
+  .arrow {
+    margin-right: .35em;
+    font-style: normal;
+  }
+
+}

--- a/src/main/sass/_fingerprint.scss
+++ b/src/main/sass/_fingerprint.scss
@@ -2,14 +2,10 @@
 // ==========================================================================
 
 .fingerprint-container {
-    margin: 35px 15px 15px 15px;
+    margin-top: 35px;
+    margin-bottom: 15px;
     background-color: $pale-grey;
     padding: 25px;
-}
-
-.fingerprint {
-    font-family: monospace;
-    white-space: pre;
 }
 
 .fingerprint-explanation {

--- a/src/main/sass/_fingerprint.scss
+++ b/src/main/sass/_fingerprint.scss
@@ -1,0 +1,17 @@
+// Digital fingerprint styles
+// ==========================================================================
+
+.fingerprint-container {
+    margin: 35px 15px 15px 15px;
+    background-color: $pale-grey;
+    padding: 25px;
+}
+
+.fingerprint {
+    font-family: monospace;
+    white-space: pre;
+}
+
+.fingerprint-explanation {
+    float: right;
+}

--- a/src/main/sass/main.scss
+++ b/src/main/sass/main.scss
@@ -154,7 +154,8 @@ dd a {
 }
 
 .technical-information {
-    margin: 35px 15px 15px 15px;
+    margin-top: 35px;
+    margin-bottom: 15px;
     padding: 25px;
     background-color: $pale-grey;
     border: 1px solid #BFC1C3;

--- a/src/main/sass/main.scss
+++ b/src/main/sass/main.scss
@@ -32,6 +32,11 @@ $image-url-path: '/assets/' !default;
 
 /* Register styles */
 
+$pale-grey: #f5f5f5;
+
+@import "details";
+@import "fingerprint";
+
 $register: #2372b5;
 $NTA-Light: $Helvetica-Regular;
 
@@ -151,7 +156,7 @@ dd a {
 .technical-information {
     margin: 35px 15px 15px 15px;
     padding: 25px;
-    background-color: #F8F8F8;
+    background-color: $pale-grey;
     border: 1px solid #BFC1C3;
 }
 


### PR DESCRIPTION
- add `<details>` tag polyfill from govuk_elements
- rationalise some uses of colour -- we previously had #f5f5f5, #f8f8f8
  and #f9f9f9 in different parts of the CSS; I've introduced a
  $pale-grey variable to capture the technical-information and
  fingerprint background colour.

Screenshots of new front page:

<img width="1045" alt="screen shot 2015-11-18 at 16 27 51" src="https://cloud.githubusercontent.com/assets/581269/11247017/21cd77f8-8e12-11e5-84a3-ef52847e891a.png">
<img width="1036" alt="screen shot 2015-11-18 at 16 27 43" src="https://cloud.githubusercontent.com/assets/581269/11247018/21d2ed6e-8e12-11e5-8ef6-ba1636dc123a.png">
