### PR TITLE
Add digital proof to record page

### DIFF
--- a/src/main/java/uk/gov/register/presentation/EntryView.java
+++ b/src/main/java/uk/gov/register/presentation/EntryView.java
@@ -48,49 +48,6 @@ public class EntryView {
     public String registerName() {
         return registerName;
     }
-
-    @SuppressWarnings("unused, used from html templates")
-    public String getAuditPath() {
-        // unimplemented; hardcoded value for now
-        return "[\n" +
-                "    \"99t31KVfWjz8ix0pWRT0KTUKJauAtc4TH1nhtyyvRjA=\",\n" +
-                "    \"IRFw6DVWcNgwxDbXhCuIuN6y51t/pfJBgKjkcJRlrEw=\",\n" +
-                "    \"DlqcXhFIdgUICJdA17917ph1vHSTXOzw/G2SXecJNTA=\",\n" +
-                "    \"5Jj7g1Y4MYvARwgOnfhDot7DkJxdYYD6Qr8Jzl1ncTI=\",\n" +
-                "    \"yEkOmJ73J4XL4Qpkv3D4qC1mN82Od/Ndbu4sXEEiOew=\",\n" +
-                "    \"uswSM2HekesEAPIGdkZERYEBEZ7hawvgqLWUz9Ewkkk=\",\n" +
-                "    \"fgO4O6M679Cl1qfCGmPK3YI6at1Jgy8rbWKGQ6qE2x8=\",\n" +
-                "    \"5gWmZgloC8TvI6rhFHmjCepyJ7kOaspGu70+JtK6W4c=\",\n" +
-                "    \"em+6WJKsyinGMrqVXLSN/bohuCw8gOyZGrinn5Q37Ek=\",\n" +
-                "    \"jgSUxKvxj54SrM6U6LdCaYb8MuexWNy6P3rKXGmPFqU=\",\n" +
-                "    \"NQKBgE3nKluraAwT+KLXQEcXeI4gVO48l+Hw8xlbwXA=\",\n" +
-                "    \"k+v2l72v43sbi62VfVqJJNNsNrAiVG9st26MY06A5tY=\",\n" +
-                "    \"8yjmDGwaIDNf4O+It4hGpXpVvXad8tD/I1qlq2P2JUQ=\",\n" +
-                "    \"i8w8ouWREDi+3vvjjnX/pNstQdU2JlIO0vt9+qGXaA0=\",\n" +
-                "    \"pCU8INpSyecydfBsX/haKkaUyfezlFOW2bAIqrXV8Ng=\",\n" +
-                "    \"fWn9RMbuj6A3t11BfWD1zM+nKN0aKdP7WoOiEYcvd+w=\",\n" +
-                "    \"SUQv6JOv8tGH82/xV63LXBpQwRfhAjchH8ComhkGa4E=\",\n" +
-                "    \"yRz2PS0g52P2sRuryDE68qtSXmia/a74+NuPckpYHc0=\",\n" +
-                "    \"eaCVxf1sLjsrN2D9QtYFrIM9jGJ6K4D+NKF9Lyifv34=\",\n" +
-                "    \"aWa1ytHZyVlvu3EYGB7NPtlAssfijpxPzzILTe6sXD8=\",\n" +
-                "    \"r454DNNoeAguA407gutu8IzNNSLlGFH2F91rqybbzFQ=\",\n" +
-                "    \"zeC0N4isU4ZrwaeCJdjy31+X9avF8zt87NN6G+xOThQ=\",\n" +
-                "    \"WBb5QnpttrokZ3kMCNNyAymfQK/BfPgIdsh3izVZgK0=\",\n" +
-                "    \"lyzm0rW0RIi1OXHwnpQ4WVB+cbSzLplTeAWrIDZaavU=\"\n" +
-                "  ]";
-    }
-
-    @SuppressWarnings("unused, used from html templates")
-    public String getSignedTreeHead() {
-        // unimplemented; hardcoded value for now
-        return "{\n" +
-                "  \"tree_size\": 9803348,\n" +
-                "  \"timestamp\": 1447421303202,\n" +
-                "  \"sha256_root_hash\": \"JATHxRF5gczvNPP1S1WuhD8jSx2bl+WoTt8bIE3YKvU=\",\n" +
-                "  \"tree_head_signature\":\n" +
-                "  \"BAMARzBFAiEAkKM3aRUBKhShdCyrGLdd8lYBV52FLrwqjHa5/YuzK7ECIFTlRmNuKLqbVQv0QS8nq0pAUwgbilKOR5piBAIC8LpS\"\n" +
-                "}";
-    }
 }
 
 

--- a/src/main/java/uk/gov/register/presentation/EntryView.java
+++ b/src/main/java/uk/gov/register/presentation/EntryView.java
@@ -48,6 +48,49 @@ public class EntryView {
     public String registerName() {
         return registerName;
     }
+
+    @SuppressWarnings("unused, used from html templates")
+    public String getAuditPath() {
+        // unimplemented; hardcoded value for now
+        return "[\n" +
+                "    \"99t31KVfWjz8ix0pWRT0KTUKJauAtc4TH1nhtyyvRjA=\",\n" +
+                "    \"IRFw6DVWcNgwxDbXhCuIuN6y51t/pfJBgKjkcJRlrEw=\",\n" +
+                "    \"DlqcXhFIdgUICJdA17917ph1vHSTXOzw/G2SXecJNTA=\",\n" +
+                "    \"5Jj7g1Y4MYvARwgOnfhDot7DkJxdYYD6Qr8Jzl1ncTI=\",\n" +
+                "    \"yEkOmJ73J4XL4Qpkv3D4qC1mN82Od/Ndbu4sXEEiOew=\",\n" +
+                "    \"uswSM2HekesEAPIGdkZERYEBEZ7hawvgqLWUz9Ewkkk=\",\n" +
+                "    \"fgO4O6M679Cl1qfCGmPK3YI6at1Jgy8rbWKGQ6qE2x8=\",\n" +
+                "    \"5gWmZgloC8TvI6rhFHmjCepyJ7kOaspGu70+JtK6W4c=\",\n" +
+                "    \"em+6WJKsyinGMrqVXLSN/bohuCw8gOyZGrinn5Q37Ek=\",\n" +
+                "    \"jgSUxKvxj54SrM6U6LdCaYb8MuexWNy6P3rKXGmPFqU=\",\n" +
+                "    \"NQKBgE3nKluraAwT+KLXQEcXeI4gVO48l+Hw8xlbwXA=\",\n" +
+                "    \"k+v2l72v43sbi62VfVqJJNNsNrAiVG9st26MY06A5tY=\",\n" +
+                "    \"8yjmDGwaIDNf4O+It4hGpXpVvXad8tD/I1qlq2P2JUQ=\",\n" +
+                "    \"i8w8ouWREDi+3vvjjnX/pNstQdU2JlIO0vt9+qGXaA0=\",\n" +
+                "    \"pCU8INpSyecydfBsX/haKkaUyfezlFOW2bAIqrXV8Ng=\",\n" +
+                "    \"fWn9RMbuj6A3t11BfWD1zM+nKN0aKdP7WoOiEYcvd+w=\",\n" +
+                "    \"SUQv6JOv8tGH82/xV63LXBpQwRfhAjchH8ComhkGa4E=\",\n" +
+                "    \"yRz2PS0g52P2sRuryDE68qtSXmia/a74+NuPckpYHc0=\",\n" +
+                "    \"eaCVxf1sLjsrN2D9QtYFrIM9jGJ6K4D+NKF9Lyifv34=\",\n" +
+                "    \"aWa1ytHZyVlvu3EYGB7NPtlAssfijpxPzzILTe6sXD8=\",\n" +
+                "    \"r454DNNoeAguA407gutu8IzNNSLlGFH2F91rqybbzFQ=\",\n" +
+                "    \"zeC0N4isU4ZrwaeCJdjy31+X9avF8zt87NN6G+xOThQ=\",\n" +
+                "    \"WBb5QnpttrokZ3kMCNNyAymfQK/BfPgIdsh3izVZgK0=\",\n" +
+                "    \"lyzm0rW0RIi1OXHwnpQ4WVB+cbSzLplTeAWrIDZaavU=\"\n" +
+                "  ]";
+    }
+
+    @SuppressWarnings("unused, used from html templates")
+    public String getSignedTreeHead() {
+        // unimplemented; hardcoded value for now
+        return "{\n" +
+                "  \"tree_size\": 9803348,\n" +
+                "  \"timestamp\": 1447421303202,\n" +
+                "  \"sha256_root_hash\": \"JATHxRF5gczvNPP1S1WuhD8jSx2bl+WoTt8bIE3YKvU=\",\n" +
+                "  \"tree_head_signature\":\n" +
+                "  \"BAMARzBFAiEAkKM3aRUBKhShdCyrGLdd8lYBV52FLrwqjHa5/YuzK7ECIFTlRmNuKLqbVQv0QS8nq0pAUwgbilKOR5piBAIC8LpS\"\n" +
+                "}";
+    }
 }
 
 

--- a/src/main/resources/templates/entry.html
+++ b/src/main/resources/templates/entry.html
@@ -17,47 +17,9 @@
 
     <div th:include="data-formats.html::data-formats"></div>
 
-    <details>
-        <summary>Check the digital proof for this entry</summary>
-        <div class="fingerprint-container">
-            <span class="fingerprint-explanation"><a href="https://gdstechnology.blog.gov.uk/2015/10/13/guaranteeing-the-integrity-of-a-register/">See how digital proofing works</a></span>
-            <pre class="fingerprint"><code>{
-  "tree_size": 9803348,
-  "timestamp": 1447421303202,
-  "sha256_root_hash": "JATHxRF5gczvNPP1S1WuhD8jSx2bl+WoTt8bIE3YKvU=",
-  "tree_head_signature":
-  "BAMARzBFAiEAkKM3aRUBKhShdCyrGLdd8lYBV52FLrwqjHa5/YuzK7ECIFTlRmNuKLqbVQv0QS8nq0pAUwgbilKOR5piBAIC8LpS"
-}<hr/>[
-    "99t31KVfWjz8ix0pWRT0KTUKJauAtc4TH1nhtyyvRjA=",
-    "IRFw6DVWcNgwxDbXhCuIuN6y51t/pfJBgKjkcJRlrEw=",
-    "DlqcXhFIdgUICJdA17917ph1vHSTXOzw/G2SXecJNTA=",
-    "5Jj7g1Y4MYvARwgOnfhDot7DkJxdYYD6Qr8Jzl1ncTI=",
-    "yEkOmJ73J4XL4Qpkv3D4qC1mN82Od/Ndbu4sXEEiOew=",
-    "uswSM2HekesEAPIGdkZERYEBEZ7hawvgqLWUz9Ewkkk=",
-    "fgO4O6M679Cl1qfCGmPK3YI6at1Jgy8rbWKGQ6qE2x8=",
-    "5gWmZgloC8TvI6rhFHmjCepyJ7kOaspGu70+JtK6W4c=",
-    "em+6WJKsyinGMrqVXLSN/bohuCw8gOyZGrinn5Q37Ek=",
-    "jgSUxKvxj54SrM6U6LdCaYb8MuexWNy6P3rKXGmPFqU=",
-    "NQKBgE3nKluraAwT+KLXQEcXeI4gVO48l+Hw8xlbwXA=",
-    "k+v2l72v43sbi62VfVqJJNNsNrAiVG9st26MY06A5tY=",
-    "8yjmDGwaIDNf4O+It4hGpXpVvXad8tD/I1qlq2P2JUQ=",
-    "i8w8ouWREDi+3vvjjnX/pNstQdU2JlIO0vt9+qGXaA0=",
-    "pCU8INpSyecydfBsX/haKkaUyfezlFOW2bAIqrXV8Ng=",
-    "fWn9RMbuj6A3t11BfWD1zM+nKN0aKdP7WoOiEYcvd+w=",
-    "SUQv6JOv8tGH82/xV63LXBpQwRfhAjchH8ComhkGa4E=",
-    "yRz2PS0g52P2sRuryDE68qtSXmia/a74+NuPckpYHc0=",
-    "eaCVxf1sLjsrN2D9QtYFrIM9jGJ6K4D+NKF9Lyifv34=",
-    "aWa1ytHZyVlvu3EYGB7NPtlAssfijpxPzzILTe6sXD8=",
-    "r454DNNoeAguA407gutu8IzNNSLlGFH2F91rqybbzFQ=",
-    "zeC0N4isU4ZrwaeCJdjy31+X9avF8zt87NN6G+xOThQ=",
-    "WBb5QnpttrokZ3kMCNNyAymfQK/BfPgIdsh3izVZgK0=",
-    "lyzm0rW0RIi1OXHwnpQ4WVB+cbSzLplTeAWrIDZaavU="
-  ]</code></pre>
-        </div>
-    </details>
+    <details th:replace="fragments/digital-proof.html :: digital-proof (sth = ${entry.signedTreeHead}, auditPath = ${entry.auditPath})"/>
 
     <p><a th:href="${versionHistoryLink}">View all versions of this record</a></p>
-
 
     <p th:replace="copyright.html::copyright"></p>
 

--- a/src/main/resources/templates/entry.html
+++ b/src/main/resources/templates/entry.html
@@ -17,7 +17,7 @@
 
     <div th:include="data-formats.html::data-formats"></div>
 
-    <details th:replace="fragments/digital-proof.html :: digital-proof (sth = ${entry.signedTreeHead}, auditPath = ${entry.auditPath})"/>
+    <details th:replace="fragments/digital-proof.html :: digital-proof"/>
 
     <p><a th:href="${versionHistoryLink}">View all versions of this record</a></p>
 

--- a/src/main/resources/templates/fragments/digital-proof.html
+++ b/src/main/resources/templates/fragments/digital-proof.html
@@ -2,13 +2,44 @@
 
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml">
 <body>
-<details th:fragment="digital-proof(sth,auditPath)">
+<details th:fragment="digital-proof">
     <summary>Check the digital proof for this entry</summary>
     <div class="fingerprint-container">
         <span class="fingerprint-explanation"><a
                 href="https://gdstechnology.blog.gov.uk/2015/10/13/guaranteeing-the-integrity-of-a-register/">See how
             digital proofing works</a></span>
-        <pre class="fingerprint"><code th:text="${sth}"/><hr/><code th:text="${auditPath}"/></pre>
+        <pre class="fingerprint"><code>{
+  "tree_size": 9803348,
+  "timestamp": 1447421303202,
+  "sha256_root_hash": "JATHxRF5gczvNPP1S1WuhD8jSx2bl+WoTt8bIE3YKvU=",
+  "tree_head_signature":
+  "BAMARzBFAiEAkKM3aRUBKhShdCyrGLdd8lYBV52FLrwqjHa5/YuzK7ECIFTlRmNuKLqbVQv0QS8nq0pAUwgbilKOR5piBAIC8LpS"
+}</code><hr/><code>[
+  "99t31KVfWjz8ix0pWRT0KTUKJauAtc4TH1nhtyyvRjA=",
+  "IRFw6DVWcNgwxDbXhCuIuN6y51t/pfJBgKjkcJRlrEw=",
+  "DlqcXhFIdgUICJdA17917ph1vHSTXOzw/G2SXecJNTA=",
+  "5Jj7g1Y4MYvARwgOnfhDot7DkJxdYYD6Qr8Jzl1ncTI=",
+  "yEkOmJ73J4XL4Qpkv3D4qC1mN82Od/Ndbu4sXEEiOew=",
+  "uswSM2HekesEAPIGdkZERYEBEZ7hawvgqLWUz9Ewkkk=",
+  "fgO4O6M679Cl1qfCGmPK3YI6at1Jgy8rbWKGQ6qE2x8=",
+  "5gWmZgloC8TvI6rhFHmjCepyJ7kOaspGu70+JtK6W4c=",
+  "em+6WJKsyinGMrqVXLSN/bohuCw8gOyZGrinn5Q37Ek=",
+  "jgSUxKvxj54SrM6U6LdCaYb8MuexWNy6P3rKXGmPFqU=",
+  "NQKBgE3nKluraAwT+KLXQEcXeI4gVO48l+Hw8xlbwXA=",
+  "k+v2l72v43sbi62VfVqJJNNsNrAiVG9st26MY06A5tY=",
+  "8yjmDGwaIDNf4O+It4hGpXpVvXad8tD/I1qlq2P2JUQ=",
+  "i8w8ouWREDi+3vvjjnX/pNstQdU2JlIO0vt9+qGXaA0=",
+  "pCU8INpSyecydfBsX/haKkaUyfezlFOW2bAIqrXV8Ng=",
+  "fWn9RMbuj6A3t11BfWD1zM+nKN0aKdP7WoOiEYcvd+w=",
+  "SUQv6JOv8tGH82/xV63LXBpQwRfhAjchH8ComhkGa4E=",
+  "yRz2PS0g52P2sRuryDE68qtSXmia/a74+NuPckpYHc0=",
+  "eaCVxf1sLjsrN2D9QtYFrIM9jGJ6K4D+NKF9Lyifv34=",
+  "aWa1ytHZyVlvu3EYGB7NPtlAssfijpxPzzILTe6sXD8=",
+  "r454DNNoeAguA407gutu8IzNNSLlGFH2F91rqybbzFQ=",
+  "zeC0N4isU4ZrwaeCJdjy31+X9avF8zt87NN6G+xOThQ=",
+  "WBb5QnpttrokZ3kMCNNyAymfQK/BfPgIdsh3izVZgK0=",
+  "lyzm0rW0RIi1OXHwnpQ4WVB+cbSzLplTeAWrIDZaavU="
+]</code></pre>
     </div>
 </details>
 </body>

--- a/src/main/resources/templates/fragments/digital-proof.html
+++ b/src/main/resources/templates/fragments/digital-proof.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+
+<html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml">
+<body>
+<details th:fragment="digital-proof(sth,auditPath)">
+    <summary>Check the digital proof for this entry</summary>
+    <div class="fingerprint-container">
+        <span class="fingerprint-explanation"><a
+                href="https://gdstechnology.blog.gov.uk/2015/10/13/guaranteeing-the-integrity-of-a-register/">See how
+            digital proofing works</a></span>
+        <pre class="fingerprint"><code th:text="${sth}"/><hr/><code th:text="${auditPath}"/></pre>
+    </div>
+</details>
+</body>
+</html>

--- a/src/main/resources/templates/latest-entry-of-record.html
+++ b/src/main/resources/templates/latest-entry-of-record.html
@@ -17,7 +17,7 @@
 
     <div th:include="data-formats.html::data-formats"></div>
 
-    <details th:replace="fragments/digital-proof.html :: digital-proof (sth = ${entry.signedTreeHead}, auditPath = ${entry.auditPath})"/>
+    <details th:replace="fragments/digital-proof.html :: digital-proof"/>
 
     <p><a th:href="${versionHistoryLink}">View all versions of this record</a>
     </p>

--- a/src/main/resources/templates/latest-entry-of-record.html
+++ b/src/main/resources/templates/latest-entry-of-record.html
@@ -17,8 +17,46 @@
 
     <div th:include="data-formats.html::data-formats"></div>
 
-    <p>View all versions of this record <a
-            th:href="${versionHistoryLink}">here</a>
+    <details>
+        <summary>Check the digital proof for this entry</summary>
+        <div class="fingerprint-container">
+            <span class="fingerprint-explanation"><a href="https://gdstechnology.blog.gov.uk/2015/10/13/guaranteeing-the-integrity-of-a-register/">See how digital proofing works</a></span>
+            <pre class="fingerprint"><code>{
+  "tree_size": 9803348,
+  "timestamp": 1447421303202,
+  "sha256_root_hash": "JATHxRF5gczvNPP1S1WuhD8jSx2bl+WoTt8bIE3YKvU=",
+  "tree_head_signature":
+  "BAMARzBFAiEAkKM3aRUBKhShdCyrGLdd8lYBV52FLrwqjHa5/YuzK7ECIFTlRmNuKLqbVQv0QS8nq0pAUwgbilKOR5piBAIC8LpS"
+}<hr/>[
+    "99t31KVfWjz8ix0pWRT0KTUKJauAtc4TH1nhtyyvRjA=",
+    "IRFw6DVWcNgwxDbXhCuIuN6y51t/pfJBgKjkcJRlrEw=",
+    "DlqcXhFIdgUICJdA17917ph1vHSTXOzw/G2SXecJNTA=",
+    "5Jj7g1Y4MYvARwgOnfhDot7DkJxdYYD6Qr8Jzl1ncTI=",
+    "yEkOmJ73J4XL4Qpkv3D4qC1mN82Od/Ndbu4sXEEiOew=",
+    "uswSM2HekesEAPIGdkZERYEBEZ7hawvgqLWUz9Ewkkk=",
+    "fgO4O6M679Cl1qfCGmPK3YI6at1Jgy8rbWKGQ6qE2x8=",
+    "5gWmZgloC8TvI6rhFHmjCepyJ7kOaspGu70+JtK6W4c=",
+    "em+6WJKsyinGMrqVXLSN/bohuCw8gOyZGrinn5Q37Ek=",
+    "jgSUxKvxj54SrM6U6LdCaYb8MuexWNy6P3rKXGmPFqU=",
+    "NQKBgE3nKluraAwT+KLXQEcXeI4gVO48l+Hw8xlbwXA=",
+    "k+v2l72v43sbi62VfVqJJNNsNrAiVG9st26MY06A5tY=",
+    "8yjmDGwaIDNf4O+It4hGpXpVvXad8tD/I1qlq2P2JUQ=",
+    "i8w8ouWREDi+3vvjjnX/pNstQdU2JlIO0vt9+qGXaA0=",
+    "pCU8INpSyecydfBsX/haKkaUyfezlFOW2bAIqrXV8Ng=",
+    "fWn9RMbuj6A3t11BfWD1zM+nKN0aKdP7WoOiEYcvd+w=",
+    "SUQv6JOv8tGH82/xV63LXBpQwRfhAjchH8ComhkGa4E=",
+    "yRz2PS0g52P2sRuryDE68qtSXmia/a74+NuPckpYHc0=",
+    "eaCVxf1sLjsrN2D9QtYFrIM9jGJ6K4D+NKF9Lyifv34=",
+    "aWa1ytHZyVlvu3EYGB7NPtlAssfijpxPzzILTe6sXD8=",
+    "r454DNNoeAguA407gutu8IzNNSLlGFH2F91rqybbzFQ=",
+    "zeC0N4isU4ZrwaeCJdjy31+X9avF8zt87NN6G+xOThQ=",
+    "WBb5QnpttrokZ3kMCNNyAymfQK/BfPgIdsh3izVZgK0=",
+    "lyzm0rW0RIi1OXHwnpQ4WVB+cbSzLplTeAWrIDZaavU="
+  ]</code></pre>
+        </div>
+    </details>
+
+    <p><a th:href="${versionHistoryLink}">View all versions of this record</a>
     </p>
 
     <p th:replace="copyright.html::copyright"></p>

--- a/src/main/resources/templates/latest-entry-of-record.html
+++ b/src/main/resources/templates/latest-entry-of-record.html
@@ -17,44 +17,7 @@
 
     <div th:include="data-formats.html::data-formats"></div>
 
-    <details>
-        <summary>Check the digital proof for this entry</summary>
-        <div class="fingerprint-container">
-            <span class="fingerprint-explanation"><a href="https://gdstechnology.blog.gov.uk/2015/10/13/guaranteeing-the-integrity-of-a-register/">See how digital proofing works</a></span>
-            <pre class="fingerprint"><code>{
-  "tree_size": 9803348,
-  "timestamp": 1447421303202,
-  "sha256_root_hash": "JATHxRF5gczvNPP1S1WuhD8jSx2bl+WoTt8bIE3YKvU=",
-  "tree_head_signature":
-  "BAMARzBFAiEAkKM3aRUBKhShdCyrGLdd8lYBV52FLrwqjHa5/YuzK7ECIFTlRmNuKLqbVQv0QS8nq0pAUwgbilKOR5piBAIC8LpS"
-}<hr/>[
-    "99t31KVfWjz8ix0pWRT0KTUKJauAtc4TH1nhtyyvRjA=",
-    "IRFw6DVWcNgwxDbXhCuIuN6y51t/pfJBgKjkcJRlrEw=",
-    "DlqcXhFIdgUICJdA17917ph1vHSTXOzw/G2SXecJNTA=",
-    "5Jj7g1Y4MYvARwgOnfhDot7DkJxdYYD6Qr8Jzl1ncTI=",
-    "yEkOmJ73J4XL4Qpkv3D4qC1mN82Od/Ndbu4sXEEiOew=",
-    "uswSM2HekesEAPIGdkZERYEBEZ7hawvgqLWUz9Ewkkk=",
-    "fgO4O6M679Cl1qfCGmPK3YI6at1Jgy8rbWKGQ6qE2x8=",
-    "5gWmZgloC8TvI6rhFHmjCepyJ7kOaspGu70+JtK6W4c=",
-    "em+6WJKsyinGMrqVXLSN/bohuCw8gOyZGrinn5Q37Ek=",
-    "jgSUxKvxj54SrM6U6LdCaYb8MuexWNy6P3rKXGmPFqU=",
-    "NQKBgE3nKluraAwT+KLXQEcXeI4gVO48l+Hw8xlbwXA=",
-    "k+v2l72v43sbi62VfVqJJNNsNrAiVG9st26MY06A5tY=",
-    "8yjmDGwaIDNf4O+It4hGpXpVvXad8tD/I1qlq2P2JUQ=",
-    "i8w8ouWREDi+3vvjjnX/pNstQdU2JlIO0vt9+qGXaA0=",
-    "pCU8INpSyecydfBsX/haKkaUyfezlFOW2bAIqrXV8Ng=",
-    "fWn9RMbuj6A3t11BfWD1zM+nKN0aKdP7WoOiEYcvd+w=",
-    "SUQv6JOv8tGH82/xV63LXBpQwRfhAjchH8ComhkGa4E=",
-    "yRz2PS0g52P2sRuryDE68qtSXmia/a74+NuPckpYHc0=",
-    "eaCVxf1sLjsrN2D9QtYFrIM9jGJ6K4D+NKF9Lyifv34=",
-    "aWa1ytHZyVlvu3EYGB7NPtlAssfijpxPzzILTe6sXD8=",
-    "r454DNNoeAguA407gutu8IzNNSLlGFH2F91rqybbzFQ=",
-    "zeC0N4isU4ZrwaeCJdjy31+X9avF8zt87NN6G+xOThQ=",
-    "WBb5QnpttrokZ3kMCNNyAymfQK/BfPgIdsh3izVZgK0=",
-    "lyzm0rW0RIi1OXHwnpQ4WVB+cbSzLplTeAWrIDZaavU="
-  ]</code></pre>
-        </div>
-    </details>
+    <details th:replace="fragments/digital-proof.html :: digital-proof (sth = ${entry.signedTreeHead}, auditPath = ${entry.auditPath})"/>
 
     <p><a th:href="${versionHistoryLink}">View all versions of this record</a>
     </p>


### PR DESCRIPTION
Similar to #118.  As the proof is basically the same, I extracted a thymeleaf fragment to capture the digital proof part (and pulled the hardcoded constants into EntryView because defining them in Thymeleaf was too horrible).
