### PR TITLE
Tidy up frontend

### DIFF
--- a/src/main/resources/assets/css/main.css
+++ b/src/main/resources/assets/css/main.css
@@ -934,6 +934,8 @@ body {
     font-weight: bold; }
   .primary-metadata dd a {
     text-decoration: none; }
+  .primary-metadata dd a:hover {
+    text-decoration: underline; }
   .primary-metadata dd .show-other-content {
     font-family: "GDS-Logo", sans-serif;
     font-size: 18px;
@@ -945,21 +947,14 @@ body {
         font-size: 24px;
         line-height: 1.25; } }
 
-.registry-label {
-  margin-top: 60px;
-  margin-bottom: 5px; }
-
-.org-name {
-  font-size: 24px;
-  margin-top: 0px;
-  margin-bottom: 15px; }
-
 .side-nav {
   font-weight: 700;
   list-style-type: none;
   line-height: 30px; }
   .side-nav a {
     text-decoration: none; }
+  .side-nav a:hover {
+    text-decoration: underline; }
 
 @media (min-width: 641px) {
   #footer .footer-meta .footer-meta-inner .custom-government-licence {
@@ -969,9 +964,6 @@ body {
   white-space: pre;
   /* fallback for IE 6-7 */
   white-space: pre-line; }
-
-dd a {
-  text-decoration: none; }
 
 .grid-row .column-third {
   padding: 0 15px;

--- a/src/main/resources/assets/css/main.css
+++ b/src/main/resources/assets/css/main.css
@@ -946,6 +946,7 @@ body {
         line-height: 1.25; } }
 
 .registry-label {
+  margin-top: 60px;
   margin-bottom: 5px; }
 
 .org-name {
@@ -971,9 +972,6 @@ body {
 
 dd a {
   text-decoration: none; }
-
-.registry-label {
-  margin-top: 60px; }
 
 .grid-row .column-third {
   padding: 0 15px;

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -10,14 +10,9 @@
         <div class="column-two-thirds">
             <div class="homepage-intro" th:utext="${registerText}">The register of UK government registers.</div>
 
-            <div class="registry">
-                <p class="registry-label">Provided by:</p>
-                <p class="org-name">
-                    <a th:href="${publicBody.recordLink}" th:text="${publicBody.name}">Cabinet Office</a>
-                </p>
-            </div>
-
             <dl class="primary-metadata">
+                <dt>Provided by:</dt>
+                <dd><a th:href="${publicBody.recordLink}" th:text="${publicBody.name}">Cabinet Office</a></dd>
                 <dt>Total records:</dt>
                 <dd><a href="/records" th:text="${totalRecords}">Total records</a></dd>
                 <dt>Last updated:</dt>
@@ -30,7 +25,7 @@
         <div class="column-two-thirds">
         <h2 class="heading-large">Technical information</h2>
             <p>Registers are made up of entries containing fields of data. To build services on top of these registers you can access the data in a variety of formats.</p>
-            <dt>Fields in this register:</dt>
+            <h3>Fields in this register:</h3>
             <div class="field-list"> <ul><li th:each="field : ${register.fields}" th:text="${field}"></li></ul> </div>
         </div>
         <div class="column-third">

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -17,6 +17,7 @@
     <div class="header-wrapper">
         <div class="header-global">
             <div class="header-logo">
+                <!--/* TODO should this be an <h1>? */-->
                 <a id="logo" class="content" href="/"
                    th:text="${friendlyRegisterName}"></a>
             </div>

--- a/src/main/sass/main.scss
+++ b/src/main/sass/main.scss
@@ -97,6 +97,7 @@ main {
 }
 
 .registry-label {
+  margin-top: 60px;
   margin-bottom: 5px;
 }
 
@@ -132,10 +133,6 @@ main {
 
 dd a {
   text-decoration: none;
-}
-
-.registry-label {
-  margin-top: 60px;
 }
 
 //grids

--- a/src/main/sass/main.scss
+++ b/src/main/sass/main.scss
@@ -90,30 +90,25 @@ main {
     a {
       text-decoration: none;
     }
+    a:hover {
+      text-decoration: underline;
+    }
     .show-other-content {
       @include bold-24;
     }
   }
 }
 
-.registry-label {
-  margin-top: 60px;
-  margin-bottom: 5px;
-}
-
-.org-name {
-  font-size: 24px;
-  margin-top: 0px;
-  margin-bottom: 15px;
-}
-
 .side-nav {
   font-weight: 700;
   list-style-type: none;
   line-height: 30px;
-    a{
-      text-decoration: none;
-    }
+  a {
+    text-decoration: none;
+  }
+  a:hover {
+    text-decoration: underline;
+  }
 }
 
 #footer .footer-meta .footer-meta-inner {
@@ -129,10 +124,6 @@ main {
 .registry-copyright {
   white-space: pre; /* fallback for IE 6-7 */
   white-space: pre-line;
-}
-
-dd a {
-  text-decoration: none;
 }
 
 //grids


### PR DESCRIPTION
- use `<dl>` consistently for all 3 items on front page
- make links underline-on-hover (for consistency with GOV.UK, among
  others)
- remove duplication from css
- remove a stray `<dt>`
- add TODO for whether page title should be `<h1>` (this is interesting
  partly because we currently have no `<h1>`s but we have `<h2>` and `<h3>`)
