### PR TITLE
Fix column widths on single entry pages

### DIFF
--- a/src/main/resources/assets/css/main.css
+++ b/src/main/resources/assets/css/main.css
@@ -975,6 +975,12 @@ body {
 .provided-by {
   display: block; }
 
+.field-column {
+  width: 33%; }
+
+.value-column {
+  width: 67%; }
+
 .grid-row .column-third {
   padding: 0 15px;
   -webkit-box-sizing: border-box;

--- a/src/main/resources/templates/fragments/entry-table.html
+++ b/src/main/resources/templates/fragments/entry-table.html
@@ -4,6 +4,10 @@
 <body>
 <div th:fragment="entry-table(content)">
     <table class="entry">
+        <colgroup>
+            <col class="field-column" />
+            <col class="value-column" />
+        </colgroup>
         <thead>
             <tr>
                 <th>Field</th>

--- a/src/main/sass/main.scss
+++ b/src/main/sass/main.scss
@@ -85,6 +85,13 @@ main {
   display: block;
 }
 
+.field-column {
+  width: 33%;
+}
+.value-column {
+  width: 67%;
+}
+
 //grids
 
 .grid-row {


### PR DESCRIPTION
This fixes our column width to one-third / two-thirds for field name and
value respectively.  This applies to the record and entry pages.
