### PR TITLE
Reformatted date as per gov.uk styles on home page

### DIFF
--- a/src/main/java/uk/gov/register/thymeleaf/HomePageView.java
+++ b/src/main/java/uk/gov/register/thymeleaf/HomePageView.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 public class HomePageView extends ThymeleafView {
-    private final static DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("dd/MM/YYYY HH:mm:ss");
+    private final static DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("d MMM uuuu");
 
     private final MarkdownProcessor markdownProcessor = new MarkdownProcessor();
 

--- a/src/test/java/uk/gov/register/thymeleaf/HomePageViewTest.java
+++ b/src/test/java/uk/gov/register/thymeleaf/HomePageViewTest.java
@@ -38,6 +38,6 @@ public class HomePageViewTest {
 
         HomePageView homePageView = new HomePageView(null, mockRequestContext, 1, localDateTime);
 
-        assertThat(homePageView.getLastUpdatedTime(), equalTo("11/09/2015 13:17:59"));
+        assertThat(homePageView.getLastUpdatedTime(), equalTo("11 Sep 2015"));
     }
 }


### PR DESCRIPTION
Showing register's last updated time as per gov.uk  styles, e.g. "3 Dec 2015".
