### PR TITLE
download as many entries as possible from bulk download page

### DIFF
--- a/src/main/resources/templates/download.html
+++ b/src/main/resources/templates/download.html
@@ -8,7 +8,7 @@
     <div th:replace="main.html::phase"></div>
     <h1>Bulk download</h1>
     <p>Download the current contents of this register as:
-        <a href="/records.json" rel="alternate">json</a>, <a href="/records.ttl" rel="alternate">ttl</a>, <a href="/records" rel="alternate">html</a>, <a href="/records.tsv" rel="alternate">tsv</a> and <a href="/records.csv" rel="alternate">csv</a>.
+        <a href="/records.json?page-size=5000" rel="alternate">json</a>, <a href="/records.ttl?page-size=5000" rel="alternate">ttl</a>, <a href="/records.tsv?page-size=5000" rel="alternate">tsv</a> and <a href="/records.csv?page-size=5000" rel="alternate">csv</a>.
     </p>
     <p><a href="/download.torrent">Download the whole history of this register</a> as a CSV by bittorrent.</p>
     <p>Once you have downloaded your copy of the register, you can keep your local copy up to date with the <a href="/entries">latest changes.</a></p>


### PR DESCRIPTION
We don't currently have a URL for "all records", but this is the closest
we have right now.  This is a hack to make it easier to download (eg)
the country register.

Also, remove the html link; not sure it makes sense here.
