### PR TITLE
bump dropwizard to 0.9.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,13 @@ configurations {
 dependencies {
     compile dropwizard, jerseyMedia, markdown, postgresClient, thymeleaf
 
+    compile(dropwizard_module_java8) {
+        exclude group: 'io.dropwizard'
+    }
+    compile(dropwizard_module_java8_jdbi) {
+        exclude group: 'io.dropwizard'
+    }
+
     testCompile dropwizardTest, junit, jsonAssert
 }
 

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -1,16 +1,17 @@
 ext {
-    dropwizard_version = '0.8.2'
-    dropwizard_java8_version = '0.8.0-1'
-    jersey_version = '2.19' // based on dropwizard 0.8.2's jersey version
+    dropwizard_version = '0.9.1'
+    dropwizard_java8_version = '0.9.0-1'
+    jersey_version = '2.22.1' // based on dropwizard 0.9.1's jersey version
 
     dropwizard = [
             "io.dropwizard:dropwizard-core:${dropwizard_version}",
             "io.dropwizard:dropwizard-configuration:${dropwizard_version}",
-            "io.dropwizard.modules:dropwizard-java8:${dropwizard_java8_version}",
-            "io.dropwizard.modules:dropwizard-java8-jdbi:${dropwizard_java8_version}",
+            "io.dropwizard:dropwizard-jdbi:${dropwizard_version}",
             "io.dropwizard:dropwizard-views:${dropwizard_version}",
             "io.dropwizard:dropwizard-assets:${dropwizard_version}"
     ]
+    dropwizard_module_java8      = "io.dropwizard.modules:dropwizard-java8:${dropwizard_java8_version}"
+    dropwizard_module_java8_jdbi = "io.dropwizard.modules:dropwizard-java8-jdbi:${dropwizard_java8_version}"
 
     jerseyMedia = "org.glassfish.jersey.media:jersey-media-multipart:${jersey_version}"
 


### PR DESCRIPTION
There's a migration guide at [1](https://github.com/dropwizard/dropwizard/wiki/Upgrade-guide-0.8.x-to-0.9.x) though it seems that we're not using
anything that needs migrating.

I added some exclusions to prevent things from the
`io.dropwizard.modules` group from pulling in `io.dropwizard`
dependencies, because they'll always be pulled in at 0.9.0, not 0.9.1.
As a result, we need to explicitly pull in dropwizard-jdbi at 0.9.1.
