### PR TITLE
Curie fields can link to non-default registries

### DIFF
--- a/src/main/java/uk/gov/register/presentation/EntryConverter.java
+++ b/src/main/java/uk/gov/register/presentation/EntryConverter.java
@@ -67,12 +67,15 @@ public class EntryConverter {
         }
 
         private FieldValue convertScalar(JsonNode value) {
-            if (field.getRegister().isPresent()) {
+            if (field.getDatatype().equals("curie")) {
+                if (value.textValue().contains(":")) {
+                    return new LinkValue.CurieValue(value.textValue());
+                } 
+                return new LinkValue(field.getRegister().get(), value.textValue());
+            } else if (field.getRegister().isPresent()) {
                 return new LinkValue(field.getRegister().get(), value.textValue());
                 //Note: the equals check below must be replaced with the specified datatype, instead of doing string comparision
                 // We should replace this once the datatype register is available
-            } else if (field.getDatatype().equals("curie")) {
-                return new LinkValue.CurieValue(value.textValue());
             } else {
                 return new StringValue(value.textValue());
             }

--- a/src/main/resources/config/fields.yaml
+++ b/src/main/resources/config/fields.yaml
@@ -813,7 +813,7 @@
     cardinality: "1"
     datatype: "curie"
     field: "business"
-    register: ""
+    register: "company"
     text: "A Limited Company, School or other legal entity that trades."
 - hash: "8db2f82cdfa898ce4ac2e82dba087dc3e9959f67"
   entry:

--- a/src/test/java/uk/gov/register/presentation/EntryConverterTest.java
+++ b/src/test/java/uk/gov/register/presentation/EntryConverterTest.java
@@ -62,4 +62,31 @@ public class EntryConverterTest {
         assertThat(curieValue.getValue(), equalTo("company:12345"));
         assertThat(curieValue.link(), equalTo("http://company.openregister.org/company/12345"));
     }
+
+    @Test
+    public void convert_convertsCurieValueToTheDefaultRegisterLink() throws IOException {
+
+        JsonNode jsonNode = MAPPER.readValue("{\"business\":\"12345\"}", JsonNode.class);
+
+        EntryView entryView = entryConverter.convert(new DbEntry(13, new DbContent("somehash", jsonNode)));
+
+        LinkValue linkValue = (LinkValue) entryView.getField("business").get();
+
+        assertThat(linkValue.getValue(), equalTo("12345"));
+        assertThat(linkValue.link(), equalTo("http://company.openregister.org/company/12345"));
+    }
+
+    @Test
+    public void convert_convertsCurieValueToASpecifiedRegisterLink() throws IOException {
+
+        JsonNode jsonNode = MAPPER.readValue("{\"business\":\"sole-trader:12345\"}", JsonNode.class);
+
+        EntryView entryView = entryConverter.convert(new DbEntry(13, new DbContent("somehash", jsonNode)));
+
+        LinkValue.CurieValue curieValue = (LinkValue.CurieValue) entryView.getField("business").get();
+
+        assertThat(curieValue.getValue(), equalTo("sole-trader:12345"));
+        assertThat(curieValue.link(), equalTo("http://sole-trader.openregister.org/sole-trader/12345"));
+    }
+
 }


### PR DESCRIPTION
If the curie field contains a complete Curie, we use that to link.
If it doesn't contain a curie, we prefix the default namespace as specified by the field definition.
