### PR TITLE
bugfix: preserve data format in pagination links

### DIFF
--- a/src/main/java/uk/gov/register/presentation/resource/DataResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/DataResource.java
@@ -55,7 +55,7 @@ public class DataResource {
     @Path("/entries")
     @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
     public EntryListView entries(@QueryParam(Pagination.INDEX_PARAM) Optional<Long> pageIndex, @QueryParam(Pagination.SIZE_PARAM) Optional<Long> pageSize) {
-        Pagination pagination = new Pagination("/entries", pageIndex, pageSize, queryDAO.getTotalEntries());
+        Pagination pagination = new Pagination(pageIndex, pageSize, queryDAO.getTotalEntries());
 
         setNextAndPreviousPageLinkHeader(pagination);
 
@@ -67,7 +67,7 @@ public class DataResource {
     @Path("/records")
     @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
     public EntryListView records(@QueryParam(Pagination.INDEX_PARAM) Optional<Long> pageIndex, @QueryParam(Pagination.SIZE_PARAM) Optional<Long> pageSize) {
-        Pagination pagination = new Pagination("/records", pageIndex, pageSize, queryDAO.getTotalRecords());
+        Pagination pagination = new Pagination(pageIndex, pageSize, queryDAO.getTotalRecords());
 
         setNextAndPreviousPageLinkHeader(pagination);
 

--- a/src/main/java/uk/gov/register/presentation/resource/Pagination.java
+++ b/src/main/java/uk/gov/register/presentation/resource/Pagination.java
@@ -11,12 +11,10 @@ public class Pagination {
     public static final String SIZE_PARAM = "page-size";
 
     private final long pageIndex;
-    private final String resourcePath;
     private final long totalEntries;
     private final long pageSize;
 
-    Pagination(String resourcePath, Optional<Long> optionalPageIndex, Optional<Long> optionalPageSize, long totalEntries) {
-        this.resourcePath = resourcePath;
+    Pagination(Optional<Long> optionalPageIndex, Optional<Long> optionalPageSize, long totalEntries) {
         this.totalEntries = totalEntries;
 
         this.pageIndex = optionalPageIndex.orElse(1L);
@@ -77,11 +75,11 @@ public class Pagination {
     }
 
     public String getNextPageLink() {
-        return String.format("%s?" + INDEX_PARAM + "=%s&" + SIZE_PARAM + "=%s", resourcePath, getNextPageNumber(), pageSize());
+        return String.format("?" + INDEX_PARAM + "=%s&" + SIZE_PARAM + "=%s", getNextPageNumber(), pageSize());
     }
 
     public String getPreviousPageLink() {
-        return String.format("%s?" + INDEX_PARAM + "=%s&" + SIZE_PARAM + "=%s", resourcePath, getPreviousPageNumber(), pageSize());
+        return String.format("?" + INDEX_PARAM + "=%s&" + SIZE_PARAM + "=%s", getPreviousPageNumber(), pageSize());
     }
 
     public long pageSize() {

--- a/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
@@ -41,7 +41,7 @@ public class SearchResource {
             return entryResponse(records.stream().findFirst(), viewFactory::getLatestEntryView);
         }
 
-        Pagination pagination = new Pagination(String.format("/%s/%s", key, value), Optional.empty(), Optional.empty(), 0);
+        Pagination pagination = new Pagination(Optional.empty(), Optional.empty(), 0);
         return viewFactory.getRecordsView(records, pagination);
     }
 

--- a/src/test/java/uk/gov/register/presentation/functional/RecordsResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/RecordsResourceFunctionalTest.java
@@ -60,13 +60,13 @@ public class RecordsResourceFunctionalTest extends FunctionalTestBase {
     @Test
     public void records_hasLinkHeaderForNextAndPreviousPage() {
         Response response = getRequest("/records.json?page-index=1&page-size=1");
-        assertThat(response.getHeaderString("Link"), equalTo("</records?page-index=2&page-size=1>; rel=\"next\""));
+        assertThat(response.getHeaderString("Link"), equalTo("<?page-index=2&page-size=1>; rel=\"next\""));
 
         response = getRequest("/records.json?page-index=2&page-size=1");
-        assertThat(response.getHeaderString("Link"), equalTo("</records?page-index=3&page-size=1>; rel=\"next\",</records?page-index=1&page-size=1>; rel=\"previous\""));
+        assertThat(response.getHeaderString("Link"), equalTo("<?page-index=3&page-size=1>; rel=\"next\",<?page-index=1&page-size=1>; rel=\"previous\""));
 
         response = getRequest("/records.json?page-index=3&page-size=1");
-        assertThat(response.getHeaderString("Link"), equalTo("</records?page-index=2&page-size=1>; rel=\"previous\""));
+        assertThat(response.getHeaderString("Link"), equalTo("<?page-index=2&page-size=1>; rel=\"previous\""));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/presentation/resource/PaginationTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/PaginationTest.java
@@ -13,62 +13,61 @@ public class PaginationTest {
 
     @Test(expected = BadRequestException.class)
     public void construct_throwsExceptionForPageSizeGreaterThan5000() {
-        new Pagination("/entries", Optional.of(1L), Optional.of(5001L), 10);
+        new Pagination(Optional.of(1L), Optional.of(5001L), 10);
     }
 
     @Test(expected = BadRequestException.class)
     public void construct_throwsExceptionWhenPageSizeIsZero() {
-        new Pagination("/entries", Optional.of(1L), Optional.of(0L), 10);
+        new Pagination(Optional.of(1L), Optional.of(0L), 10);
     }
 
     @Test(expected = BadRequestException.class)
     public void construct_throwsExceptionWhenPageSizeIsNegativeNumber() {
-        new Pagination("/entries", Optional.of(1L), Optional.of(-1L), 10);
+        new Pagination(Optional.of(1L), Optional.of(-1L), 10);
     }
 
     @Test(expected = BadRequestException.class)
     public void construct_throwsExceptionWhenPageIndexIsZero() {
-        new Pagination("/entries", Optional.of(0L), Optional.of(1L), 10);
+        new Pagination(Optional.of(0L), Optional.of(1L), 10);
     }
 
     @Test(expected = BadRequestException.class)
     public void construct_throwsExceptionWhenPageIndexIsNegativeNumber() {
-        new Pagination("/entries", Optional.of(-1L), Optional.of(1L), 10);
+        new Pagination(Optional.of(-1L), Optional.of(1L), 10);
     }
 
     @Test(expected = NotFoundException.class)
     public void construct_throwsNotFoundException_whenNoMoreEntriesForGivenPageSizeAndPageIndexValues() {
-        new Pagination("/entries", Optional.of(2L), Optional.of(10L), 10);
+        new Pagination(Optional.of(2L), Optional.of(10L), 10);
     }
 
     @Test
     public void offset_returnsTheNumberWhichOffsetsTheTotalEntriesBasedOnPageSize() {
-        assertThat(new Pagination("/entries", Optional.of(1L), Optional.of(10L), 100).offset(), equalTo(0L));
-        assertThat(new Pagination("/entries", Optional.of(2L), Optional.of(10L), 100).offset(), equalTo(10L));
+        assertThat(new Pagination(Optional.of(1L), Optional.of(10L), 100).offset(), equalTo(0L));
+        assertThat(new Pagination(Optional.of(2L), Optional.of(10L), 100).offset(), equalTo(10L));
     }
 
     @Test
     public void hasNextPage_returnsTrueOnlyWhenThereAreMoreEntriesAvailable() {
-        assertFalse(new Pagination("/entries", Optional.of(1L), Optional.of(10L), 10).hasNextPage());
-        assertFalse(new Pagination("/entries", Optional.of(2L), Optional.of(10L), 20).hasNextPage());
+        assertFalse(new Pagination(Optional.of(1L), Optional.of(10L), 10).hasNextPage());
+        assertFalse(new Pagination(Optional.of(2L), Optional.of(10L), 20).hasNextPage());
 
-        assertTrue(new Pagination("/entries", Optional.of(1L), Optional.of(10L), 11).hasNextPage());
+        assertTrue(new Pagination(Optional.of(1L), Optional.of(10L), 11).hasNextPage());
 
-        assertTrue(new Pagination("/entries", Optional.of(2L), Optional.of(10L), 21).hasNextPage());
+        assertTrue(new Pagination(Optional.of(2L), Optional.of(10L), 21).hasNextPage());
     }
 
     @Test
     public void hasPreviousPage_returnsTrueOnlyWhenPageIndexIsMoreThanOne() {
-        assertFalse(new Pagination("/entries", Optional.of(1L), Optional.of(10L), 10).hasPreviousPage());
-        assertFalse(new Pagination("/entries", Optional.of(1L), Optional.of(10L), 11).hasPreviousPage());
+        assertFalse(new Pagination(Optional.of(1L), Optional.of(10L), 10).hasPreviousPage());
+        assertFalse(new Pagination(Optional.of(1L), Optional.of(10L), 11).hasPreviousPage());
 
-        assertTrue(new Pagination("/entries", Optional.of(2L), Optional.of(10L), 11).hasPreviousPage());
+        assertTrue(new Pagination(Optional.of(2L), Optional.of(10L), 11).hasPreviousPage());
     }
 
     @Test
     public void getTotalPages_returnsTotalNumberOfPages() {
         Pagination pagination = new Pagination(
-                "/entries",
                 Optional.of(1L),
                 Optional.of(10L),
                 10);
@@ -76,7 +75,6 @@ public class PaginationTest {
 
 
         pagination = new Pagination(
-                "/entries",
                 Optional.of(1L),
                 Optional.of(10L),
                 11);
@@ -86,39 +84,39 @@ public class PaginationTest {
 
     @Test
     public void getNextPageLink_returnsTheLinkForNextPage() {
-        Pagination pagination = new Pagination("/entries", Optional.of(1L), Optional.of(10L), 11);
-        assertThat(pagination.getNextPageLink(), equalTo("/entries?page-index=2&page-size=10"));
+        Pagination pagination = new Pagination(Optional.of(1L), Optional.of(10L), 11);
+        assertThat(pagination.getNextPageLink(), equalTo("?page-index=2&page-size=10"));
     }
 
     @Test
     public void getPreviousPageLink_returnsTheLinkForPreviousPage() {
-        Pagination pagination = new Pagination("/entries", Optional.of(2L), Optional.of(10L), 11);
-        assertThat(pagination.getPreviousPageLink(), equalTo("/entries?page-index=1&page-size=10"));
+        Pagination pagination = new Pagination(Optional.of(2L), Optional.of(10L), 11);
+        assertThat(pagination.getPreviousPageLink(), equalTo("?page-index=1&page-size=10"));
     }
 
     @Test
     public void getFirstEntryNumberOnThisPage_returnsTheNumberOfFirstEntryOnPage() {
-        Pagination pagination = new Pagination("/entries", Optional.of(2L), Optional.of(10L), 11);
+        Pagination pagination = new Pagination(Optional.of(2L), Optional.of(10L), 11);
         assertThat(pagination.getFirstEntryNumberOnThisPage(), equalTo(11L));
     }
 
     @Test
     public void getLastEntryNumberOnThisPage_returnsTheNumberOfLastEntryOnPage() {
-        Pagination pagination = new Pagination("/entries", Optional.of(2L), Optional.of(10L), 12);
+        Pagination pagination = new Pagination(Optional.of(2L), Optional.of(10L), 12);
         assertThat(pagination.getLastEntryNumberOnThisPage(), equalTo(12L));
     }
 
     @Test
     public void isSinglePage_retrunsTrue_whenPageContainsAllEntries() {
-        Pagination pagination = new Pagination("/entries", Optional.of(1L), Optional.of(100L), 99);
+        Pagination pagination = new Pagination(Optional.of(1L), Optional.of(100L), 99);
         assertThat(pagination.isSinglePage(), equalTo(true));
-        pagination = new Pagination("/entries", Optional.of(1L), Optional.of(100L), 100);
+        pagination = new Pagination(Optional.of(1L), Optional.of(100L), 100);
         assertThat(pagination.isSinglePage(), equalTo(true));
     }
 
     @Test
     public void isSinglePage_retrunsFalse_whenPageDoesNotContainsAllEntries() {
-        Pagination pagination = new Pagination("/entries", Optional.of(2L), Optional.of(50L), 99);
+        Pagination pagination = new Pagination(Optional.of(2L), Optional.of(50L), 99);
         assertThat(pagination.isSinglePage(), equalTo(false));
     }
 


### PR DESCRIPTION
There was a bug where fetching a specific data format such as
`/records.json` would provide pagination links that stripped the data
format from the path -- eg `/records?page-index=2`.

This commit fixes that bug by using query-string-relative URLs instead:
ie a relative URL that begins with a question mark `?` preserves the
existing URL up to the path and only replaces the query string. See
https://url.spec.whatwg.org/#relative-state for more on this.

This means we can get rid of some code: the Pagination no longer needs
to know the resource path of the paginated resource.
