### PR TITLE
UrlEncode the hash for hrefs

### DIFF
--- a/src/main/java/uk/gov/register/presentation/Version.java
+++ b/src/main/java/uk/gov/register/presentation/Version.java
@@ -1,8 +1,16 @@
 package uk.gov.register.presentation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 public class Version {
+    private final Logger LOGGER = LoggerFactory.getLogger(Version.class);
+
     @JsonProperty
     public final String hash;
     @JsonProperty("serial-number")
@@ -11,5 +19,14 @@ public class Version {
     public Version(int serialNumber, String hash) {
         this.hash = hash;
         this.serialNumber = serialNumber;
+    }
+
+    public String getUrlEncodedHash() {
+        try {
+            return URLEncoder.encode(hash, StandardCharsets.UTF_8.toString());
+        } catch (UnsupportedEncodingException e) {
+            LOGGER.error(e.toString());
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/resources/templates/history.html
+++ b/src/main/resources/templates/history.html
@@ -20,7 +20,7 @@
                     <a th:href="${'/entry/' + version.serialNumber}" th:text="${version.serialNumber}"></a>
                 </td>
                 <td>
-                    <a th:href="${'/hash/' + version.hash}" th:text="${version.hash}"></a>
+                    <a th:href="${'/hash/' + version.urlEncodedHash}" th:text="${version.hash}"></a>
                 </td>
             </tr>
         </tbody>


### PR DESCRIPTION
"View All Entries" uses the entry hash as the target for the link, but the Base64 dictionary includes character instructions ("/", "+" and "="), thus breaking the link target.
