### PR TITLE
Removed /current and /feed resources

### DIFF
--- a/src/main/java/uk/gov/register/presentation/resource/DataResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/DataResource.java
@@ -75,20 +75,6 @@ public class DataResource {
         return viewFactory.getRecordsView(queryDAO.getLatestEntriesOfRecords(pagination.pageSize(), pagination.offset()), pagination);
     }
 
-    @GET
-    @Path("/feed")
-    @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
-    public Response feed(@QueryParam("pageIndex") Optional<Long> pageIndex, @QueryParam("pageSize") Optional<Long> pageSize) {
-        return create301Response("/entries", pageIndex, pageSize);
-    }
-
-    @GET
-    @Path("/current")
-    @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
-    public Response current(@QueryParam("pageIndex") Optional<Long> pageIndex, @QueryParam("pageSize") Optional<Long> pageSize) {
-        return create301Response("/records", pageIndex, pageSize);
-    }
-
     private Optional<String> getFileExtension() {
         String requestURI = requestContext.getHttpServletRequest().getRequestURI();
         if (requestURI.lastIndexOf('.') == -1) {

--- a/src/test/java/uk/gov/register/presentation/functional/EntriesResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/EntriesResourceFunctionalTest.java
@@ -6,8 +6,6 @@ import org.junit.Test;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 
-import java.io.IOException;
-
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -25,14 +23,5 @@ public class EntriesResourceFunctionalTest extends FunctionalTestBase {
         Response response = getRequest("address", "/entries.json");
         assertThat(response.getStatus(), equalTo(200));
         assertThat(response.getHeaderString(HttpHeaders.CONTENT_DISPOSITION), containsString("filename=\"address-entries.json\""));
-    }
-
-    @Test
-    public void feed_movedPermanentlyToFeedSoReturns301() throws InterruptedException, IOException {
-        Response response = getRequest("/feed.json");
-
-        assertThat(response.getStatus(), equalTo(301));
-        assertThat(response.getHeaderString("Location"), equalTo("http://address.beta.openregister.org/entries.json"));
-
     }
 }

--- a/src/test/java/uk/gov/register/presentation/functional/RecordsResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/RecordsResourceFunctionalTest.java
@@ -9,7 +9,6 @@ import uk.gov.register.presentation.functional.testSupport.DBSupport;
 
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
-import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -46,15 +45,6 @@ public class RecordsResourceFunctionalTest extends FunctionalTestBase {
         Response response = getRequest("address", "/records.json");
         assertThat(response.getStatus(), equalTo(200));
         assertThat(response.getHeaderString(HttpHeaders.CONTENT_DISPOSITION), containsString("filename=\"address-records.json\""));
-    }
-
-    @Test
-    public void current_movedPermanentlyToRecordsSoReturns301() throws InterruptedException, IOException {
-        Response response = getRequest("/current.json");
-
-        assertThat(response.getStatus(), equalTo(301));
-        assertThat(response.getHeaderString("Location"), equalTo("http://address.beta.openregister.org/records.json"));
-
     }
 
     @Test

--- a/src/test/java/uk/gov/register/presentation/resource/DataResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/DataResourceTest.java
@@ -12,16 +12,13 @@ import uk.gov.register.presentation.view.ViewFactory;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
-import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unchecked")
 @RunWith(MockitoJUnitRunner.class)
@@ -69,46 +66,5 @@ public class DataResourceTest {
                 ExtraMediaType.TEXT_TSV,
                 ExtraMediaType.TEXT_TTL
         ));
-    }
-
-    @Test
-    public void currentWithRepresentation_permanentlyRedirectsToRecordsWithSameRepresentation() {
-
-        when(requestContext.requestURI()).thenReturn("http://abc/current.json");
-
-        Response response = dataResource.current(Optional.empty(), Optional.empty());
-
-        assertThat(response.getStatus(), equalTo(301));
-        assertThat(response.getHeaderString("Location"), equalTo("http://abc/records.json"));
-    }
-
-    @Test
-    public void currentWithoutRepresentation_permanentlyRedirectsToRecordsWithoputRepresentation() {
-        when(requestContext.requestURI()).thenReturn("http://abc/current");
-
-        Response response = dataResource.current(Optional.empty(), Optional.empty());
-
-        assertThat(response.getStatus(), equalTo(301));
-        assertThat(response.getHeaderString("Location"), equalTo("http://abc/records"));
-    }
-
-    @Test
-    public void feedWithRepresentation_permanentlyRedirectsToEntriesWithSameRepresentation() {
-        when(requestContext.requestURI()).thenReturn("http://abc/entries.json");
-
-        Response response = dataResource.feed(Optional.empty(), Optional.empty());
-
-        assertThat(response.getStatus(), equalTo(301));
-        assertThat(response.getHeaderString("Location"), equalTo("http://abc/entries.json"));
-    }
-
-    @Test
-    public void feedWithoutRepresentation_permanentlyRedirectsToEntiresWithoputRepresentation() {
-        when(requestContext.requestURI()).thenReturn("http://abc/feed");
-
-        Response response = dataResource.feed(Optional.empty(), Optional.empty());
-
-        assertThat(response.getStatus(), equalTo(301));
-        assertThat(response.getHeaderString("Location"), equalTo("http://abc/entries"));
     }
 }


### PR DESCRIPTION
These were not used anywhere and simply redirecting to /records and /entries .
