### PR TITLE
implemented '/proof/certificate-transparency' resource

### DIFF
--- a/src/main/java/uk/gov/register/presentation/SignedTreeHead.java
+++ b/src/main/java/uk/gov/register/presentation/SignedTreeHead.java
@@ -1,0 +1,18 @@
+package uk.gov.register.presentation;
+
+public class SignedTreeHead {
+    public final int tree_size;
+
+    public final long timestamp;
+
+    public final String sha256_root_hash;
+
+    public final String tree_head_signature;
+
+    public SignedTreeHead(int tree_size, long timestamp, String sha256_root_hash, String tree_head_signature) {
+        this.tree_size = tree_size;
+        this.timestamp = timestamp;
+        this.sha256_root_hash = sha256_root_hash;
+        this.tree_head_signature = tree_head_signature;
+    }
+}

--- a/src/main/java/uk/gov/register/presentation/app/PresentationApplication.java
+++ b/src/main/java/uk/gov/register/presentation/app/PresentationApplication.java
@@ -32,6 +32,7 @@ import uk.gov.register.presentation.config.PresentationConfiguration;
 import uk.gov.register.presentation.config.PublicBodiesConfiguration;
 import uk.gov.register.presentation.config.RegistersConfiguration;
 import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
+import uk.gov.register.presentation.dao.SignedTreeHeadQueryDAO;
 import uk.gov.register.presentation.representations.*;
 import uk.gov.register.presentation.resource.*;
 import uk.gov.register.presentation.view.ViewFactory;
@@ -77,6 +78,7 @@ public class PresentationApplication extends Application<PresentationConfigurati
         DBIFactory dbiFactory = new DBIFactory();
         DBI jdbi = dbiFactory.build(environment, configuration.getDatabase(), "postgres");
         RecentEntryIndexQueryDAO queryDAO = jdbi.onDemand(RecentEntryIndexQueryDAO.class);
+        SignedTreeHeadQueryDAO signedTreeHeadQueryDAO = jdbi.onDemand(SignedTreeHeadQueryDAO.class);
 
         JerseyEnvironment jerseyEnvironment = environment.jersey();
         DropwizardResourceConfig resourceConfig = jerseyEnvironment.getResourceConfig();
@@ -97,6 +99,7 @@ public class PresentationApplication extends Application<PresentationConfigurati
             @Override
             protected void configure() {
                 bind(queryDAO).to(RecentEntryIndexQueryDAO.class);
+                bind(signedTreeHeadQueryDAO).to(SignedTreeHeadQueryDAO.class);
                 bind(FieldsConfiguration.class).to(FieldsConfiguration.class).in(Singleton.class);
                 bind(PublicBodiesConfiguration.class).to(PublicBodiesConfiguration.class).in(Singleton.class);
                 bind(RegistersConfiguration.class).to(RegistersConfiguration.class).in(Singleton.class);

--- a/src/main/java/uk/gov/register/presentation/dao/SignedTreeHeadQueryDAO.java
+++ b/src/main/java/uk/gov/register/presentation/dao/SignedTreeHeadQueryDAO.java
@@ -1,0 +1,25 @@
+package uk.gov.register.presentation.dao;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+import uk.gov.register.presentation.SignedTreeHead;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public interface SignedTreeHeadQueryDAO {
+
+    @RegisterMapper(SignedTreeHeadMapper.class)
+    @SqlQuery("SELECT * FROM sth")
+    SignedTreeHead get();
+
+
+    class SignedTreeHeadMapper implements ResultSetMapper<SignedTreeHead> {
+        @Override
+        public SignedTreeHead map(int index, ResultSet r, StatementContext ctx) throws SQLException {
+            return new SignedTreeHead(r.getInt("tree_size"), r.getLong("timestamp"), r.getString("sha256_root_hash"), r.getString("tree_head_signature"));
+        }
+    }
+}

--- a/src/main/java/uk/gov/register/presentation/dao/SignedTreeHeadQueryDAO.java
+++ b/src/main/java/uk/gov/register/presentation/dao/SignedTreeHeadQueryDAO.java
@@ -4,7 +4,7 @@ import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
-import uk.gov.register.presentation.SignedTreeHead;
+import uk.gov.register.proofs.ct.SignedTreeHead;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;

--- a/src/main/java/uk/gov/register/presentation/resource/RegisterProofResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/RegisterProofResource.java
@@ -21,7 +21,7 @@ public class RegisterProofResource {
     }
 
     @GET
-    @Path("/register/proof")
+    @Path("/proof/certificate-transparency")
     @Produces(MediaType.APPLICATION_JSON)
     public RegisterProofView getRegisterDetails() throws JsonProcessingException {
         return new RegisterProofView(signedTreeHeadQueryDAO.get());

--- a/src/main/java/uk/gov/register/presentation/resource/RegisterProofResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/RegisterProofResource.java
@@ -1,0 +1,29 @@
+package uk.gov.register.presentation.resource;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import uk.gov.register.presentation.dao.SignedTreeHeadQueryDAO;
+import uk.gov.register.thymeleaf.RegisterProofView;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+
+@Path("/")
+public class RegisterProofResource {
+    private SignedTreeHeadQueryDAO signedTreeHeadQueryDAO;
+
+    @Inject
+    public RegisterProofResource(SignedTreeHeadQueryDAO signedTreeHeadQueryDAO) {
+        this.signedTreeHeadQueryDAO = signedTreeHeadQueryDAO;
+    }
+
+    @GET
+    @Path("/register/proof")
+    @Produces(MediaType.APPLICATION_JSON)
+    public RegisterProofView getRegisterDetails() throws JsonProcessingException {
+        return new RegisterProofView(signedTreeHeadQueryDAO.get());
+    }
+}

--- a/src/main/java/uk/gov/register/proofs/ct/SignedTreeHead.java
+++ b/src/main/java/uk/gov/register/proofs/ct/SignedTreeHead.java
@@ -1,4 +1,4 @@
-package uk.gov.register.presentation;
+package uk.gov.register.proofs.ct;
 
 public class SignedTreeHead {
     public final int tree_size;

--- a/src/main/java/uk/gov/register/thymeleaf/RegisterProofView.java
+++ b/src/main/java/uk/gov/register/thymeleaf/RegisterProofView.java
@@ -1,0 +1,20 @@
+package uk.gov.register.thymeleaf;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.dropwizard.views.View;
+import uk.gov.register.presentation.SignedTreeHead;
+
+public class RegisterProofView extends View {
+    private final SignedTreeHead signedTreeHead;
+
+    public RegisterProofView(SignedTreeHead signedTreeHead) {
+        super("");
+        this.signedTreeHead = signedTreeHead;
+    }
+
+    @SuppressWarnings("unused, represents the json response")
+    @JsonValue
+    public SignedTreeHead getSignedTreeHead() {
+        return signedTreeHead;
+    }
+}

--- a/src/main/java/uk/gov/register/thymeleaf/RegisterProofView.java
+++ b/src/main/java/uk/gov/register/thymeleaf/RegisterProofView.java
@@ -2,7 +2,8 @@ package uk.gov.register.thymeleaf;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.dropwizard.views.View;
-import uk.gov.register.presentation.SignedTreeHead;
+import uk.gov.register.proofs.ct.SignedTreeHead;
+
 
 public class RegisterProofView extends View {
     private final SignedTreeHead signedTreeHead;

--- a/src/test/java/uk/gov/register/presentation/functional/FunctionalTestBase.java
+++ b/src/test/java/uk/gov/register/presentation/functional/FunctionalTestBase.java
@@ -13,12 +13,10 @@ public class FunctionalTestBase {
     public static final String DATABASE_USER = "postgres";
     public static final int APPLICATION_PORT = 9000;
 
-    private static final String TABLE_NAME = "ordered_entry_index";
-
     protected static Client client;
 
     @ClassRule
-    public static CleanDatabaseRule cleanDatabaseRule = new CleanDatabaseRule(DATABASE_URL, DATABASE_USER, TABLE_NAME);
+    public static CleanDatabaseRule cleanDatabaseRule = new CleanDatabaseRule(DATABASE_URL, DATABASE_USER, "ordered_entry_index");
 
     @BeforeClass
     public static void beforeClass() throws InterruptedException {

--- a/src/test/java/uk/gov/register/presentation/functional/RegisterProofResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/RegisterProofResourceTest.java
@@ -20,7 +20,7 @@ public class RegisterProofResourceTest extends FunctionalTestBase {
 
     @Test
     public void shouldReturnSTHJson() throws JSONException {
-        Response response = getRequest("/register/proof.json");
+        Response response = getRequest("/proof/certificate-transparency.json");
 
         String jsonResponse = response.readEntity(String.class);
 

--- a/src/test/java/uk/gov/register/presentation/functional/RegisterProofResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/RegisterProofResourceTest.java
@@ -1,0 +1,35 @@
+package uk.gov.register.presentation.functional;
+
+import org.json.JSONException;
+import org.junit.Before;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import uk.gov.register.presentation.functional.testSupport.DBSupport;
+
+import javax.ws.rs.core.Response;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class RegisterProofResourceTest extends FunctionalTestBase {
+
+    @Before
+    public void setup() {
+        DBSupport.writeSignedTreeHead(9876, 1453204760135L, "rootHash", "treeSignature");
+    }
+
+    @Test
+    public void shouldReturnSTHJson() throws JSONException {
+        Response response = getRequest("/register/proof.json");
+
+        String jsonResponse = response.readEntity(String.class);
+
+        assertThat(response.getStatus(), equalTo(200));
+        JSONAssert.assertEquals("{" +
+                "        \"tree_size\": 9876," +
+                "        \"timestamp\": 1453204760135," +
+                "        \"sha256_root_hash\": \"rootHash\"," +
+                "        \"tree_head_signature\": \"treeSignature\"" +
+                "    }", jsonResponse, false);
+    }
+}

--- a/src/test/java/uk/gov/register/presentation/functional/testSupport/CleanDatabaseRule.java
+++ b/src/test/java/uk/gov/register/presentation/functional/testSupport/CleanDatabaseRule.java
@@ -31,6 +31,9 @@ public class CleanDatabaseRule extends ExternalResource {
             connection.prepareStatement("DROP TABLE IF EXISTS TOTAL_RECORDS").execute();
             connection.prepareStatement("CREATE TABLE TOTAL_RECORDS (COUNT INTEGER)").execute();
             connection.prepareStatement("INSERT INTO TOTAL_RECORDS(COUNT) VALUES(0)").execute();
+
+            connection.prepareStatement("DROP TABLE IF EXISTS STH").execute();
+            connection.prepareStatement("create table sth (tree_size integer, timestamp bigint, tree_head_signature varchar, sha256_root_hash varchar)").execute();
         }
     }
 }


### PR DESCRIPTION
Implemented resource which returns the signed tree head of the register to prove the integrity of data in register.

The resource returns the following json response:

```
{
  "tree_size": "9803348",
  "timestamp": "1447421303202",
  "sha256_root_hash": "JATHxRF5gczvNPP1S1WuhD8jSx2bl+WoTt8bIE3YKvU=",
  "tree_head_signature":
  "BAMARzBFAiEAkKM3aRUBKhShdCyrGLdd8lYBV52FLrwqjHa5/YuzK7ECIFTlRmNuKLqbVQv0QS8nq0pAUwgbilKOR5piBAIC8LpS"
}
```

The register proof view does not have any html template yet so it always returns json response. We need more clarity over the html pages for the resources. psd and @stephenjoe1 are working on it.
