### PR TITLE
Rename of URL and/or parameters for /hash and /entry

### DIFF
--- a/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
@@ -47,19 +47,19 @@ public class SearchResource {
     }
 
     @GET
-    @Path("/item/{itemHash}")
+    @Path("/item/{item-hash}")
     @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
     @CacheControl(immutable = true)
-    public SingleEntryView findByItemHash(@PathParam("itemHash") String itemHash) {
+    public SingleEntryView findByItemHash(@PathParam("item-hash") String itemHash) {
         Optional<DbEntry> entryO = queryDAO.findEntryByHash(itemHash);
         return entryResponse(entryO, viewFactory::getSingleEntryView);
     }
 
     @GET
-    @Path("/entry/{serial}")
+    @Path("/entry/{entry-number}")
     @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
     @CacheControl(immutable = true)
-    public SingleEntryView findBySerial(@PathParam("serial") String serialString) {
+    public SingleEntryView findBySerial(@PathParam("entry-number") String serialString) {
         Optional<Integer> serial = Optional.ofNullable(Ints.tryParse(serialString));
         Optional<DbEntry> entryO = serial.flatMap(queryDAO::findEntryBySerialNumber);
         return entryResponse(entryO, viewFactory::getSingleEntryView);

--- a/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
@@ -47,11 +47,11 @@ public class SearchResource {
     }
 
     @GET
-    @Path("/hash/{hash}")
+    @Path("/item/{itemHash}")
     @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
     @CacheControl(immutable = true)
-    public SingleEntryView findByHash(@PathParam("hash") String hash) {
-        Optional<DbEntry> entryO = queryDAO.findEntryByHash(hash);
+    public SingleEntryView findByItemHash(@PathParam("itemHash") String itemHash) {
+        Optional<DbEntry> entryO = queryDAO.findEntryByHash(itemHash);
         return entryResponse(entryO, viewFactory::getSingleEntryView);
     }
 

--- a/src/main/resources/templates/history.html
+++ b/src/main/resources/templates/history.html
@@ -20,7 +20,7 @@
                     <a th:href="${'/entry/' + version.serialNumber}" th:text="${version.serialNumber}"></a>
                 </td>
                 <td>
-                    <a th:href="${'/hash/' + version.hash}" th:text="${version.hash}"></a>
+                    <a th:href="${'/item/' + version.hash}" th:text="${version.hash}"></a>
                 </td>
             </tr>
         </tbody>

--- a/src/test/java/uk/gov/register/presentation/HtmlViewSupportTest.java
+++ b/src/test/java/uk/gov/register/presentation/HtmlViewSupportTest.java
@@ -20,25 +20,25 @@ public class HtmlViewSupportTest {
 
     @Test
     public void representationLink_addTheRepresentationSuffixForNonHtmlRepresentation() throws URISyntaxException {
-        when(servletRequest.getRequestURI()).thenReturn("/hash/hashvalue");
+        when(servletRequest.getRequestURI()).thenReturn("/item/hashvalue");
         when(servletRequest.getParameterMap()).thenReturn(Collections.singletonMap("query", new String[]{"value"}));
         String link = HtmlViewSupport.representationLink(servletRequest, "json");
-        assertThat(link, equalTo("/hash/hashvalue.json?query=value"));
+        assertThat(link, equalTo("/item/hashvalue.json?query=value"));
     }
 
     @Test
     public void representationLink_maintainTheSameRepresentationSuffix() throws URISyntaxException {
-        when(servletRequest.getRequestURI()).thenReturn("/hash/hashvalue.csv");
+        when(servletRequest.getRequestURI()).thenReturn("/item/hashvalue.csv");
         when(servletRequest.getParameterMap()).thenReturn(Collections.singletonMap("query", new String[]{"value"}));
         String link = HtmlViewSupport.representationLink(servletRequest, "csv");
-        assertThat(link, equalTo("/hash/hashvalue.csv?query=value"));
+        assertThat(link, equalTo("/item/hashvalue.csv?query=value"));
     }
 
     @Test
     public void representationLink_doNotAddRepresentationSuffixForHTMLRepresentation() throws URISyntaxException {
-        when(servletRequest.getRequestURI()).thenReturn("/hash/hashvalue.json");
+        when(servletRequest.getRequestURI()).thenReturn("/item/hashvalue.json");
         when(servletRequest.getParameterMap()).thenReturn(Collections.singletonMap("query", new String[]{"value"}));
         String link = HtmlViewSupport.representationLink(servletRequest, "html");
-        assertThat(link, equalTo("/hash/hashvalue?query=value"));
+        assertThat(link, equalTo("/item/hashvalue?query=value"));
     }
 }

--- a/src/test/java/uk/gov/register/presentation/functional/FindEntityTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/FindEntityTest.java
@@ -32,7 +32,7 @@ public class FindEntityTest extends FunctionalTestBase {
     }
 
     @Test
-    public void findByHash_shouldReturnEntryForTheGivenHash() throws Exception {
+    public void findByItemHash_shouldReturnEntryForTheGivenHash() throws Exception {
         Response response = getRequest("/entry/2.json");
 
         assertThat(response.getHeaderString("Link"), equalTo("</address/6789/history>;rel=\"version-history\""));

--- a/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
@@ -58,10 +58,10 @@ public class SearchResourceTest {
     }
 
     @Test
-    public void findByHash_throwsNotFoundWhenHashIsNotFound() {
+    public void findByItemHash_throwsNotFoundWhenHashIsNotFound() {
         when(queryDAO.findEntryByHash("123")).thenReturn(Optional.<DbEntry>empty());
         try {
-            resource.findByHash("123");
+            resource.findByItemHash("123");
             fail("Must fail");
         } catch (NotFoundException e) {
             //success
@@ -126,9 +126,9 @@ public class SearchResourceTest {
     }
 
     @Test
-    public void findByHashSupportsTurtleHtmlAndJson() throws Exception {
-        Method findByHashMethod = SearchResource.class.getDeclaredMethod("findByHash", String.class);
-        List<String> declaredMediaTypes = asList(findByHashMethod.getDeclaredAnnotation(Produces.class).value());
+    public void findByItemHashSupportsTurtleHtmlAndJson() throws Exception {
+        Method findByItemHashMethod = SearchResource.class.getDeclaredMethod("findByItemHash", String.class);
+        List<String> declaredMediaTypes = asList(findByItemHashMethod.getDeclaredAnnotation(Produces.class).value());
         assertThat(declaredMediaTypes,
                 hasItems(ExtraMediaType.TEXT_HTML,
                         MediaType.APPLICATION_JSON,


### PR DESCRIPTION
I can change /hash/{hash} to /item/{item-hash} and /entry/{serial-number} to /entry/{entry-number}, but /records should return entry/item xref but at present it returns entry+itemData.
