### PR TITLE
Make register domain configurable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,7 @@ server:
     - type: http
       port: 9092
 
-registerDomain: .openregister.dev:8080
+registerDomain: openregister.dev:8080
 
 database:
   driverClass: org.postgresql.Driver

--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,8 @@ server:
     - type: http
       port: 9092
 
+registerDomain: .openregister.dev:8080
+
 database:
   driverClass: org.postgresql.Driver
   url: jdbc:postgresql://localhost:5432/school

--- a/src/main/java/uk/gov/register/presentation/EntryConverter.java
+++ b/src/main/java/uk/gov/register/presentation/EntryConverter.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Iterables;
 import org.jvnet.hk2.annotations.Service;
 import uk.gov.register.presentation.config.Field;
 import uk.gov.register.presentation.config.FieldsConfiguration;
+import uk.gov.register.presentation.config.RegisterDomainConfiguration;
 import uk.gov.register.presentation.resource.RequestContext;
 
 import javax.inject.Inject;
@@ -19,10 +20,14 @@ import static uk.gov.register.presentation.Cardinality.ONE;
 public class EntryConverter {
     private final FieldsConfiguration fieldsConfiguration;
     private final RequestContext requestContext;
+    private final String registerDomain;
 
     @Inject
-    public EntryConverter(FieldsConfiguration fieldsConfiguration, RequestContext requestContext) {
+    public EntryConverter(FieldsConfiguration fieldsConfiguration,
+                          RegisterDomainConfiguration domainConfiguration,
+                          RequestContext requestContext) {
         this.fieldsConfiguration = fieldsConfiguration;
+        this.registerDomain = domainConfiguration.getRegisterDomain();
         this.requestContext = requestContext;
     }
 
@@ -44,7 +49,7 @@ public class EntryConverter {
         return fieldConverter.convert(value);
     }
 
-    private static class FieldConverter {
+    private class FieldConverter {
         private final Field field;
 
         public FieldConverter(Field field) {
@@ -69,11 +74,11 @@ public class EntryConverter {
         private FieldValue convertScalar(JsonNode value) {
             if (field.getDatatype().equals("curie")) {
                 if (value.textValue().contains(":")) {
-                    return new LinkValue.CurieValue(value.textValue());
+                    return new LinkValue.CurieValue(value.textValue(), registerDomain);
                 } 
-                return new LinkValue(field.getRegister().get(), value.textValue());
+                return new LinkValue(field.getRegister().get(), registerDomain, value.textValue());
             } else if (field.getRegister().isPresent()) {
-                return new LinkValue(field.getRegister().get(), value.textValue());
+                return new LinkValue(field.getRegister().get(), registerDomain, value.textValue());
                 //Note: the equals check below must be replaced with the specified datatype, instead of doing string comparision
                 // We should replace this once the datatype register is available
             } else {

--- a/src/main/java/uk/gov/register/presentation/HtmlViewSupport.java
+++ b/src/main/java/uk/gov/register/presentation/HtmlViewSupport.java
@@ -23,4 +23,8 @@ public class HtmlViewSupport {
     public static String fieldLink(String fieldName, String registerDomain) {
         return new LinkValue("field", registerDomain, fieldName).link();
     }
+
+    public static String publicBodyLink(String fieldName, String registerDomain) {
+        return new LinkValue("public-body", registerDomain, fieldName).link();
+    }
 }

--- a/src/main/java/uk/gov/register/presentation/HtmlViewSupport.java
+++ b/src/main/java/uk/gov/register/presentation/HtmlViewSupport.java
@@ -21,6 +21,6 @@ public class HtmlViewSupport {
     }
 
     public static String fieldLink(String fieldName) {
-        return new LinkValue("field", fieldName).link();
+        return new LinkValue("field", ".openregister.org", fieldName).link();
     }
 }

--- a/src/main/java/uk/gov/register/presentation/HtmlViewSupport.java
+++ b/src/main/java/uk/gov/register/presentation/HtmlViewSupport.java
@@ -20,7 +20,7 @@ public class HtmlViewSupport {
         return uriBuilder.build().toString();
     }
 
-    public static String fieldLink(String fieldName) {
-        return new LinkValue("field", ".openregister.org", fieldName).link();
+    public static String fieldLink(String fieldName, String registerDomain) {
+        return new LinkValue("field", registerDomain, fieldName).link();
     }
 }

--- a/src/main/java/uk/gov/register/presentation/LinkValue.java
+++ b/src/main/java/uk/gov/register/presentation/LinkValue.java
@@ -3,17 +3,17 @@ package uk.gov.register.presentation;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public class LinkValue implements FieldValue {
-    private static final String template = "http://%1$s.openregister.org/%1$s/%2$s";
+    private static final String template = "http://%1$s%2$s/%1$s/%3$s";
     private final String value;
     private final String link;
 
-    public LinkValue(String registerName, String value) {
-        this(registerName, value, value);
+    public LinkValue(String registerName, String registerDomain, String value) {
+        this(registerName, registerDomain, value, value);
     }
 
-    private LinkValue(String registerName, String value, String linkKey){
+    private LinkValue(String registerName, String registerDomain, String value, String linkKey){
         this.value = value;
-        this.link = String.format(template, registerName, linkKey);
+        this.link = String.format(template, registerName, registerDomain, linkKey);
     }
 
     @Override
@@ -36,8 +36,8 @@ public class LinkValue implements FieldValue {
     }
 
     public static class CurieValue extends LinkValue {
-        public CurieValue(String curieValue) {
-            super(curieValue.split(":")[0], curieValue, curieValue.split(":")[1]);
+        public CurieValue(String curieValue, String registerDomain) {
+            super(curieValue.split(":")[0], registerDomain, curieValue, curieValue.split(":")[1]);
         }
     }
 }

--- a/src/main/java/uk/gov/register/presentation/LinkValue.java
+++ b/src/main/java/uk/gov/register/presentation/LinkValue.java
@@ -3,7 +3,7 @@ package uk.gov.register.presentation;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public class LinkValue implements FieldValue {
-    private static final String template = "http://%1$s%2$s/%1$s/%3$s";
+    private static final String template = "http://%1$s.%2$s/%1$s/%3$s";
     private final String value;
     private final String link;
 

--- a/src/main/java/uk/gov/register/presentation/config/PresentationConfiguration.java
+++ b/src/main/java/uk/gov/register/presentation/config/PresentationConfiguration.java
@@ -10,7 +10,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.net.URI;
 
-public class PresentationConfiguration extends Configuration implements GovukClientConfiguration {
+public class PresentationConfiguration extends Configuration implements GovukClientConfiguration, RegisterDomainConfiguration {
     @Valid
     @NotNull
     @JsonProperty
@@ -20,6 +20,16 @@ public class PresentationConfiguration extends Configuration implements GovukCli
     @NotNull
     @JsonProperty
     private DataSourceFactory database;
+
+    @Valid
+    @NotNull
+    @JsonProperty
+    private String registerDomain = ".openregister.org";
+
+    @Override
+    public String getRegisterDomain() {
+        return registerDomain;
+    }
 
     public DataSourceFactory getDatabase() {
         return database;

--- a/src/main/java/uk/gov/register/presentation/config/PresentationConfiguration.java
+++ b/src/main/java/uk/gov/register/presentation/config/PresentationConfiguration.java
@@ -24,7 +24,7 @@ public class PresentationConfiguration extends Configuration implements GovukCli
     @Valid
     @NotNull
     @JsonProperty
-    private String registerDomain = ".openregister.org";
+    private String registerDomain = "openregister.org";
 
     @Override
     public String getRegisterDomain() {

--- a/src/main/java/uk/gov/register/presentation/config/PublicBody.java
+++ b/src/main/java/uk/gov/register/presentation/config/PublicBody.java
@@ -28,6 +28,6 @@ public class PublicBody {
     @SuppressWarnings("unused, used from html templates")
     @JsonIgnore
     public String getRecordLink(){
-        return new LinkValue("public-body", publicBodyId).link();
+        return new LinkValue("public-body", ".openregister.org", publicBodyId).link();
     }
 }

--- a/src/main/java/uk/gov/register/presentation/config/PublicBody.java
+++ b/src/main/java/uk/gov/register/presentation/config/PublicBody.java
@@ -1,10 +1,8 @@
 package uk.gov.register.presentation.config;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import uk.gov.register.presentation.LinkValue;
 
 @JsonIgnoreProperties({"text","crest","website","parent-bodies","official-colour","public-body-type"})
 public class PublicBody {
@@ -23,11 +21,5 @@ public class PublicBody {
 
     public String getPublicBodyId() {
         return publicBodyId;
-    }
-
-    @SuppressWarnings("unused, used from html templates")
-    @JsonIgnore
-    public String getRecordLink(){
-        return new LinkValue("public-body", ".openregister.org", publicBodyId).link();
     }
 }

--- a/src/main/java/uk/gov/register/presentation/config/RegisterDomainConfiguration.java
+++ b/src/main/java/uk/gov/register/presentation/config/RegisterDomainConfiguration.java
@@ -1,0 +1,8 @@
+package uk.gov.register.presentation.config;
+
+import org.jvnet.hk2.annotations.Contract;
+
+@Contract
+public interface RegisterDomainConfiguration {
+    String getRegisterDomain();
+}

--- a/src/main/java/uk/gov/register/presentation/representations/TurtleWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/TurtleWriter.java
@@ -24,7 +24,7 @@ import java.util.stream.StreamSupport;
 @Produces(ExtraMediaType.TEXT_TTL)
 @Service
 public class TurtleWriter extends RepresentationWriter {
-    private static final String PREFIX_FORMAT = "@prefix field: <http://field%s/field/>.\n\n";
+    private static final String PREFIX_FORMAT = "@prefix field: <http://field.%s/field/>.\n\n";
 
     private final RequestContext requestContext;
     private final String prefix;

--- a/src/main/java/uk/gov/register/presentation/representations/TurtleWriter.java
+++ b/src/main/java/uk/gov/register/presentation/representations/TurtleWriter.java
@@ -5,6 +5,7 @@ import uk.gov.register.presentation.EntryView;
 import uk.gov.register.presentation.FieldValue;
 import uk.gov.register.presentation.LinkValue;
 import uk.gov.register.presentation.ListValue;
+import uk.gov.register.presentation.config.RegisterDomainConfiguration;
 import uk.gov.register.presentation.resource.RequestContext;
 
 import javax.inject.Inject;
@@ -23,18 +24,20 @@ import java.util.stream.StreamSupport;
 @Produces(ExtraMediaType.TEXT_TTL)
 @Service
 public class TurtleWriter extends RepresentationWriter {
-    private static final String PREFIX = "@prefix field: <http://field.openregister.org/field/>.\n\n";
+    private static final String PREFIX_FORMAT = "@prefix field: <http://field%s/field/>.\n\n";
 
     private final RequestContext requestContext;
+    private final String prefix;
 
     @Inject
-    public TurtleWriter(RequestContext requestContext) {
+    public TurtleWriter(RequestContext requestContext, RegisterDomainConfiguration registerDomainConfiguration) {
         this.requestContext = requestContext;
+        this.prefix = String.format(PREFIX_FORMAT, registerDomainConfiguration.getRegisterDomain());
     }
 
     @Override
     protected void writeEntriesTo(OutputStream entityStream, Iterable<String> fields, List<EntryView> entries) throws IOException {
-        entityStream.write(PREFIX.getBytes(StandardCharsets.UTF_8));
+        entityStream.write(prefix.getBytes(StandardCharsets.UTF_8));
         for (EntryView entry : entries) {
             entityStream.write((renderEntry(entry, fields) + "\n").getBytes(StandardCharsets.UTF_8));
         }

--- a/src/main/java/uk/gov/register/presentation/resource/RequestContext.java
+++ b/src/main/java/uk/gov/register/presentation/resource/RequestContext.java
@@ -3,6 +3,7 @@ package uk.gov.register.presentation.resource;
 import org.jvnet.hk2.annotations.Service;
 import uk.gov.register.presentation.RegisterNameExtractor;
 import uk.gov.register.presentation.config.Register;
+import uk.gov.register.presentation.config.RegisterDomainConfiguration;
 import uk.gov.register.presentation.config.RegistersConfiguration;
 
 import javax.inject.Inject;
@@ -25,9 +26,12 @@ public class RequestContext {
 
     private final RegistersConfiguration registersConfiguration;
 
+    private final String registerDomain;
+
     @Inject
-    public RequestContext(RegistersConfiguration registersConfiguration) {
+    public RequestContext(RegistersConfiguration registersConfiguration, RegisterDomainConfiguration domainConfiguration) {
         this.registersConfiguration = registersConfiguration;
+        this.registerDomain = domainConfiguration.getRegisterDomain();
     }
 
     public String requestURI() {
@@ -56,5 +60,9 @@ public class RequestContext {
 
     public Register getRegister() {
         return registersConfiguration.getRegister(getRegisterPrimaryKey());
+    }
+
+    public String getRegisterDomain() {
+        return registerDomain;
     }
 }

--- a/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
+++ b/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
@@ -8,6 +8,7 @@ import uk.gov.register.presentation.EntryConverter;
 import uk.gov.register.presentation.Version;
 import uk.gov.register.presentation.config.PublicBodiesConfiguration;
 import uk.gov.register.presentation.config.PublicBody;
+import uk.gov.register.presentation.config.RegisterDomainConfiguration;
 import uk.gov.register.presentation.resource.Pagination;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.register.thymeleaf.BadRequestExceptionView;
@@ -27,13 +28,19 @@ public class ViewFactory {
     private final EntryConverter entryConverter;
     private final PublicBodiesConfiguration publicBodiesConfiguration;
     private final GovukOrganisationClient organisationClient;
+    private final String registerDomain;
 
     @Inject
-    public ViewFactory(RequestContext requestContext, EntryConverter entryConverter, PublicBodiesConfiguration publicBodiesConfiguration, GovukOrganisationClient organisationClient) {
+    public ViewFactory(RequestContext requestContext,
+                       EntryConverter entryConverter,
+                       PublicBodiesConfiguration publicBodiesConfiguration,
+                       GovukOrganisationClient organisationClient,
+                       RegisterDomainConfiguration domainConfiguration) {
         this.requestContext = requestContext;
         this.entryConverter = entryConverter;
         this.publicBodiesConfiguration = publicBodiesConfiguration;
         this.organisationClient = organisationClient;
+        this.registerDomain = domainConfiguration.getRegisterDomain();
     }
 
     public SingleEntryView getSingleEntryView(DbEntry dbEntry) {
@@ -73,7 +80,7 @@ public class ViewFactory {
     }
 
     public HomePageView homePageView(int totalRecords, LocalDateTime lastUpdated) {
-        return new HomePageView(getCustodian(), getBranding(), requestContext, totalRecords, lastUpdated);
+        return new HomePageView(getCustodian(), getBranding(), requestContext, totalRecords, lastUpdated, registerDomain);
     }
 
     public ListVersionView listVersionView(List<Version> versions) throws Exception {

--- a/src/main/java/uk/gov/register/thymeleaf/HomePageView.java
+++ b/src/main/java/uk/gov/register/thymeleaf/HomePageView.java
@@ -17,17 +17,20 @@ public class HomePageView extends AttributionView {
 
     private final LocalDateTime lastUpdated;
     private final int totalRecords;
+    private final String registerDomain;
 
     public HomePageView(
             PublicBody custodian,
             Optional<GovukOrganisation.Details> custodianBranding,
             RequestContext requestContext,
             int totalRecords,
-            LocalDateTime lastUpdated
+            LocalDateTime lastUpdated,
+            String registerDomain
     ) {
         super(requestContext, custodian, custodianBranding, "home.html");
         this.totalRecords = totalRecords;
         this.lastUpdated = lastUpdated;
+        this.registerDomain = registerDomain;
     }
 
     @SuppressWarnings("unused, used from template")
@@ -47,6 +50,6 @@ public class HomePageView extends AttributionView {
 
     @SuppressWarnings("unused, used from template")
     public String getLinkToRegisterRegister(){
-        return new LinkValue("register", ".openregister.org", getRegisterId()).link();
+        return new LinkValue("register", registerDomain, getRegisterId()).link();
     }
 }

--- a/src/main/java/uk/gov/register/thymeleaf/HomePageView.java
+++ b/src/main/java/uk/gov/register/thymeleaf/HomePageView.java
@@ -47,6 +47,6 @@ public class HomePageView extends AttributionView {
 
     @SuppressWarnings("unused, used from template")
     public String getLinkToRegisterRegister(){
-        return new LinkValue("register", getRegisterId()).link();
+        return new LinkValue("register", ".openregister.org", getRegisterId()).link();
     }
 }

--- a/src/main/java/uk/gov/register/thymeleaf/ThymeleafView.java
+++ b/src/main/java/uk/gov/register/thymeleaf/ThymeleafView.java
@@ -50,6 +50,10 @@ public class ThymeleafView extends View {
         return requestContext.getRegister();
     }
 
+    public String getRegisterDomain() {
+        return requestContext.getRegisterDomain();
+    }
+
     public ServletContext getServletContext() {
         return requestContext.getServletContext();
     }

--- a/src/main/resources/templates/entries.html
+++ b/src/main/resources/templates/entries.html
@@ -15,9 +15,9 @@
         <thead>
         <tr>
             <th>Entry</th>
-            <th><a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(registerId)}" th:text="${registerId}"></a></th>
+            <th><a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(registerId, registerDomain)}" th:text="${registerId}"></a></th>
             <th:block th:each="fieldName : ${register.nonPrimaryFields}">
-                <th><a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(fieldName)}" th:text="${fieldName}"></a></th>
+                <th><a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(fieldName, registerDomain)}" th:text="${fieldName}"></a></th>
             </th:block>
         </tr>
         </thead>

--- a/src/main/resources/templates/fragments/entry-table.html
+++ b/src/main/resources/templates/fragments/entry-table.html
@@ -17,7 +17,7 @@
         <tbody>
             <tr th:each="keyValue : ${content}">
                 <td>
-                    <a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(keyValue.key)}"
+                    <a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(keyValue.key, registerDomain)}"
                        th:text="${keyValue.key}"></a>
                 </td>
 

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -33,8 +33,8 @@
 </div>
 
 <th:block th:fragment="organisation(organisation, branding)">
-    <a th:if="${branding.present}" th:href="${organisation.recordLink}" th:utext="${#strings.replace(branding.get().logoFormattedName,'\r\n','&lt;br/&gt;')}" class="organisation-logo" th:classappend="|organisation-logo-${branding.get().logoClassName} ${branding.get().colourClassName}|">Cabinet Office</a>
-    <a th:unless="${branding.present}" th:href="${organisation.recordLink}" th:text="${organisation.name}" class="organisation-logo organisation-logo-no-identity">Cabinet Office</a>
+    <a th:if="${branding.present}" th:href="${@uk.gov.register.presentation.HtmlViewSupport@publicBodyLink(organisation.publicBodyId, registerDomain)}" th:utext="${#strings.replace(branding.get().logoFormattedName,'\r\n','&lt;br/&gt;')}" class="organisation-logo" th:classappend="|organisation-logo-${branding.get().logoClassName} ${branding.get().colourClassName}|">Cabinet Office</a>
+    <a th:unless="${branding.present}" th:href="${@uk.gov.register.presentation.HtmlViewSupport@publicBodyLink(organisation.publicBodyId, registerDomain)}" th:text="${organisation.name}" class="organisation-logo organisation-logo-no-identity">Cabinet Office</a>
 </th:block>
 
 <div th:fragment="attribution">

--- a/src/main/resources/templates/records.html
+++ b/src/main/resources/templates/records.html
@@ -13,9 +13,9 @@
     <table th:if="${#lists.isEmpty(entries) == false}">
         <thead>
             <tr>
-                <th><a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(registerId)}" th:text="${registerId}"></a></th>
+                <th><a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(registerId, registerDomain)}" th:text="${registerId}"></a></th>
                 <th:block th:each="fieldName : ${register.nonPrimaryFields}">
-                    <th><a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(fieldName)}" th:text="${fieldName}"></a></th>
+                    <th><a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(fieldName, registerDomain)}" th:text="${fieldName}"></a></th>
                 </th:block>
             </tr>
         </thead>

--- a/src/test/java/uk/gov/register/presentation/EntryConverterTest.java
+++ b/src/test/java/uk/gov/register/presentation/EntryConverterTest.java
@@ -26,7 +26,7 @@ public class EntryConverterTest {
 
     @Before
     public void setUp() throws Exception {
-        entryConverter = new EntryConverter(new FieldsConfiguration(), requestContext);
+        entryConverter = new EntryConverter(new FieldsConfiguration(), () -> ".test.register.gov.uk", requestContext);
     }
 
     @Test
@@ -35,7 +35,7 @@ public class EntryConverterTest {
 
         EntryView entryView = entryConverter.convert(new DbEntry(13, new DbContent("somehash", jsonNode)));
 
-        assertThat(((LinkValue) entryView.getField("registry").get()).link(), equalTo("http://public-body.openregister.org/public-body/somevalue"));
+        assertThat(((LinkValue) entryView.getField("registry").get()).link(), equalTo("http://public-body.test.register.gov.uk/public-body/somevalue"));
     }
 
     @SuppressWarnings("unchecked")
@@ -47,7 +47,7 @@ public class EntryConverterTest {
 
         ListValue fields = (ListValue) entryView.getField("fields").get();
 
-        assertThat(fields, contains(samePropertyValuesAs(new LinkValue("field", "value1")), samePropertyValuesAs(new LinkValue("field", "value2"))));
+        assertThat(fields, contains(samePropertyValuesAs(new LinkValue("field", ".test.register.gov.uk", "value1")), samePropertyValuesAs(new LinkValue("field", ".test.register.gov.uk", "value2"))));
     }
 
     @Test
@@ -60,7 +60,7 @@ public class EntryConverterTest {
         LinkValue.CurieValue curieValue = (LinkValue.CurieValue) entryView.getField("business").get();
 
         assertThat(curieValue.getValue(), equalTo("company:12345"));
-        assertThat(curieValue.link(), equalTo("http://company.openregister.org/company/12345"));
+        assertThat(curieValue.link(), equalTo("http://company.test.register.gov.uk/company/12345"));
     }
 
     @Test
@@ -73,7 +73,7 @@ public class EntryConverterTest {
         LinkValue linkValue = (LinkValue) entryView.getField("business").get();
 
         assertThat(linkValue.getValue(), equalTo("12345"));
-        assertThat(linkValue.link(), equalTo("http://company.openregister.org/company/12345"));
+        assertThat(linkValue.link(), equalTo("http://company.test.register.gov.uk/company/12345"));
     }
 
     @Test
@@ -86,7 +86,7 @@ public class EntryConverterTest {
         LinkValue.CurieValue curieValue = (LinkValue.CurieValue) entryView.getField("business").get();
 
         assertThat(curieValue.getValue(), equalTo("sole-trader:12345"));
-        assertThat(curieValue.link(), equalTo("http://sole-trader.openregister.org/sole-trader/12345"));
+        assertThat(curieValue.link(), equalTo("http://sole-trader.test.register.gov.uk/sole-trader/12345"));
     }
 
 }

--- a/src/test/java/uk/gov/register/presentation/EntryConverterTest.java
+++ b/src/test/java/uk/gov/register/presentation/EntryConverterTest.java
@@ -26,7 +26,7 @@ public class EntryConverterTest {
 
     @Before
     public void setUp() throws Exception {
-        entryConverter = new EntryConverter(new FieldsConfiguration(), () -> ".test.register.gov.uk", requestContext);
+        entryConverter = new EntryConverter(new FieldsConfiguration(), () -> "test.register.gov.uk", requestContext);
     }
 
     @Test
@@ -47,7 +47,7 @@ public class EntryConverterTest {
 
         ListValue fields = (ListValue) entryView.getField("fields").get();
 
-        assertThat(fields, contains(samePropertyValuesAs(new LinkValue("field", ".test.register.gov.uk", "value1")), samePropertyValuesAs(new LinkValue("field", ".test.register.gov.uk", "value2"))));
+        assertThat(fields, contains(samePropertyValuesAs(new LinkValue("field", "test.register.gov.uk", "value1")), samePropertyValuesAs(new LinkValue("field", "test.register.gov.uk", "value2"))));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/presentation/representations/TurtleWriterTest.java
+++ b/src/test/java/uk/gov/register/presentation/representations/TurtleWriterTest.java
@@ -25,7 +25,7 @@ public class TurtleWriterTest {
 
     @Before
     public void setUp() throws Exception {
-        RequestContext requestContext = new RequestContext(new RegistersConfiguration()) {
+        RequestContext requestContext = new RequestContext(new RegistersConfiguration(), () -> ".test.register.gov.uk") {
             @Override
             public String requestUrl() {
                 return "http://widget.openregister.org/widget/123";

--- a/src/test/java/uk/gov/register/presentation/representations/TurtleWriterTest.java
+++ b/src/test/java/uk/gov/register/presentation/representations/TurtleWriterTest.java
@@ -49,7 +49,7 @@ public class TurtleWriterTest {
     public void rendersLinksCorrectlyAsUrls() throws Exception {
         Map<String, FieldValue> entryMap =
                 ImmutableMap.of(
-                        "registered-address", new LinkValue("address", "1111111"),
+                        "registered-address", new LinkValue("address", ".test.register.gov.uk", "1111111"),
                         "name", new StringValue("foo")
                 );
 
@@ -60,7 +60,7 @@ public class TurtleWriterTest {
         turtleWriter.writeEntriesTo(entityStream, ImmutableSet.of("company", "registered-address", "name"), Collections.singletonList(entry));
 
 
-        assertThat(entityStream.contents, containsString("field:registered-address <http://address.openregister.org/address/1111111>"));
+        assertThat(entityStream.contents, containsString("field:registered-address <http://address.test.register.gov.uk/address/1111111>"));
         assertThat(entityStream.contents, containsString("field:name \"foo\""));
     }
 
@@ -68,7 +68,7 @@ public class TurtleWriterTest {
     public void rendersLists() throws Exception {
         Map<String, FieldValue> entryMap =
                 ImmutableMap.of(
-                        "link-values", new ListValue(asList(new LinkValue("address", "1111111"), new LinkValue("address", "2222222"))),
+                        "link-values", new ListValue(asList(new LinkValue("address", ".test.register.gov.uk", "1111111"), new LinkValue("address", ".test.register.gov.uk", "2222222"))),
                         "string-values", new ListValue(asList(new StringValue("value1"), new StringValue("value2"))),
                         "name", new StringValue("foo")
                 );
@@ -80,8 +80,8 @@ public class TurtleWriterTest {
         turtleWriter.writeEntriesTo(entityStream, ImmutableSet.of("link-values", "string-values", "name"), Collections.singletonList(entry));
 
 
-        assertThat(entityStream.contents, containsString("field:link-values <http://address.openregister.org/address/1111111>"));
-        assertThat(entityStream.contents, containsString("field:link-values <http://address.openregister.org/address/2222222>"));
+        assertThat(entityStream.contents, containsString("field:link-values <http://address.test.register.gov.uk/address/1111111>"));
+        assertThat(entityStream.contents, containsString("field:link-values <http://address.test.register.gov.uk/address/2222222>"));
         assertThat(entityStream.contents, containsString("field:string-values \"value1\""));
         assertThat(entityStream.contents, containsString("field:string-values \"value2\""));
         assertThat(entityStream.contents, containsString("field:name \"foo\""));

--- a/src/test/java/uk/gov/register/presentation/representations/TurtleWriterTest.java
+++ b/src/test/java/uk/gov/register/presentation/representations/TurtleWriterTest.java
@@ -46,6 +46,17 @@ public class TurtleWriterTest {
     }
 
     @Test
+    public void rendersEntryIdentifierFromRequestContext() throws Exception {
+        EntryView entry = new EntryView(52, "abcd", "registerName", Collections.emptyMap());
+
+        TestOutputStream entityStream = new TestOutputStream();
+
+        turtleWriter.writeEntriesTo(entityStream, Collections.emptySet(), Collections.singletonList(entry));
+
+        assertThat(entityStream.contents, containsString("<http://widget.openregister.org/entry/52>"));
+    }
+
+    @Test
     public void rendersLinksCorrectlyAsUrls() throws Exception {
         Map<String, FieldValue> entryMap =
                 ImmutableMap.of(

--- a/src/test/java/uk/gov/register/presentation/representations/TurtleWriterTest.java
+++ b/src/test/java/uk/gov/register/presentation/representations/TurtleWriterTest.java
@@ -25,13 +25,13 @@ public class TurtleWriterTest {
 
     @Before
     public void setUp() throws Exception {
-        RequestContext requestContext = new RequestContext(new RegistersConfiguration(), () -> ".test.register.gov.uk") {
+        RequestContext requestContext = new RequestContext(new RegistersConfiguration(), () -> "test.register.gov.uk") {
             @Override
             public String requestUrl() {
                 return "http://widget.openregister.org/widget/123";
             }
         };
-        turtleWriter = new TurtleWriter(requestContext, () -> ".test.register.gov.uk");
+        turtleWriter = new TurtleWriter(requestContext, () -> "test.register.gov.uk");
     }
 
     @Test
@@ -49,7 +49,7 @@ public class TurtleWriterTest {
     public void rendersLinksCorrectlyAsUrls() throws Exception {
         Map<String, FieldValue> entryMap =
                 ImmutableMap.of(
-                        "registered-address", new LinkValue("address", ".test.register.gov.uk", "1111111"),
+                        "registered-address", new LinkValue("address", "test.register.gov.uk", "1111111"),
                         "name", new StringValue("foo")
                 );
 
@@ -68,7 +68,7 @@ public class TurtleWriterTest {
     public void rendersLists() throws Exception {
         Map<String, FieldValue> entryMap =
                 ImmutableMap.of(
-                        "link-values", new ListValue(asList(new LinkValue("address", ".test.register.gov.uk", "1111111"), new LinkValue("address", ".test.register.gov.uk", "2222222"))),
+                        "link-values", new ListValue(asList(new LinkValue("address", "test.register.gov.uk", "1111111"), new LinkValue("address", "test.register.gov.uk", "2222222"))),
                         "string-values", new ListValue(asList(new StringValue("value1"), new StringValue("value2"))),
                         "name", new StringValue("foo")
                 );

--- a/src/test/java/uk/gov/register/presentation/representations/TurtleWriterTest.java
+++ b/src/test/java/uk/gov/register/presentation/representations/TurtleWriterTest.java
@@ -31,7 +31,18 @@ public class TurtleWriterTest {
                 return "http://widget.openregister.org/widget/123";
             }
         };
-        turtleWriter = new TurtleWriter(requestContext);
+        turtleWriter = new TurtleWriter(requestContext, () -> ".test.register.gov.uk");
+    }
+
+    @Test
+    public void rendersFieldPrefixFromConfiguration() throws Exception {
+        EntryView entry = new EntryView(52, "abcd", "registerName", Collections.emptyMap());
+
+        TestOutputStream entityStream = new TestOutputStream();
+
+        turtleWriter.writeEntriesTo(entityStream, Collections.emptySet(), Collections.singletonList(entry));
+
+        assertThat(entityStream.contents, containsString("@prefix field: <http://field.test.register.gov.uk/field/>."));
     }
 
     @Test

--- a/src/test/java/uk/gov/register/presentation/resource/HistoryResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/HistoryResourceTest.java
@@ -37,7 +37,7 @@ public class HistoryResourceTest {
 
     @Before
     public void setUp() throws Exception {
-        resource = new HistoryResource(new RequestContext(new RegistersConfiguration()) {
+        resource = new HistoryResource(new RequestContext(new RegistersConfiguration(), () -> "") {
             @Override
             public String getRegisterPrimaryKey() {
                 return "school";

--- a/src/test/java/uk/gov/register/presentation/resource/RequestContextTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/RequestContextTest.java
@@ -19,7 +19,7 @@ public class RequestContextTest {
 
     @Test
     public void takesRegisterNameFromHttpHost() throws Exception {
-        RequestContext requestContext = new RequestContext(new RegistersConfiguration());
+        RequestContext requestContext = new RequestContext(new RegistersConfiguration(), () -> "");
         requestContext.httpServletRequest = httpServletRequest;
         when(httpServletRequest.getHeader("Host")).thenReturn("school.beta.openregister.org");
 
@@ -30,7 +30,7 @@ public class RequestContextTest {
 
     @Test
     public void behavesGracefullyWhenGivenHostWithNoDots() throws Exception {
-        RequestContext requestContext = new RequestContext(new RegistersConfiguration());
+        RequestContext requestContext = new RequestContext(new RegistersConfiguration(), () -> "");
         requestContext.httpServletRequest = httpServletRequest;
         when(httpServletRequest.getHeader("Host")).thenReturn("school");
 

--- a/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
@@ -43,7 +43,7 @@ public class SearchResourceTest {
 
     @Before
     public void setUp() throws Exception {
-        requestContext = new RequestContext(new RegistersConfiguration()){
+        requestContext = new RequestContext(new RegistersConfiguration(), () -> ""){
             @Override
             public HttpServletResponse getHttpServletResponse() {
                 return servletResponse;

--- a/src/test/java/uk/gov/register/thymeleaf/HomePageViewTest.java
+++ b/src/test/java/uk/gov/register/thymeleaf/HomePageViewTest.java
@@ -22,7 +22,7 @@ public class HomePageViewTest {
 
     @Test
     public void getRegisterText_rendersRegisterTextAsMarkdown() throws Exception {
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, null);
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, null, ".openregister.org");
 
         String registerText = "foo *bar* [baz](/quux)";
         when(mockRequestContext.getRegister()).thenReturn(new Register("", Sets.newSet(), "", "", registerText));
@@ -36,7 +36,7 @@ public class HomePageViewTest {
     public void getLastUpdatedTime_formatsTheLocalDateTimeToUKDateTimeFormat() {
         LocalDateTime localDateTime = LocalDateTime.of(2015, 9, 11, 13, 17, 59, 543);
 
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, localDateTime);
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, localDateTime, ".openregister.org");
 
         assertThat(homePageView.getLastUpdatedTime(), equalTo("11 Sep 2015"));
     }

--- a/src/test/java/uk/gov/register/thymeleaf/HomePageViewTest.java
+++ b/src/test/java/uk/gov/register/thymeleaf/HomePageViewTest.java
@@ -22,7 +22,7 @@ public class HomePageViewTest {
 
     @Test
     public void getRegisterText_rendersRegisterTextAsMarkdown() throws Exception {
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, null, ".openregister.org");
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, null, "openregister.org");
 
         String registerText = "foo *bar* [baz](/quux)";
         when(mockRequestContext.getRegister()).thenReturn(new Register("", Sets.newSet(), "", "", registerText));
@@ -36,7 +36,7 @@ public class HomePageViewTest {
     public void getLastUpdatedTime_formatsTheLocalDateTimeToUKDateTimeFormat() {
         LocalDateTime localDateTime = LocalDateTime.of(2015, 9, 11, 13, 17, 59, 543);
 
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, localDateTime, ".openregister.org");
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, localDateTime, "openregister.org");
 
         assertThat(homePageView.getLastUpdatedTime(), equalTo("11 Sep 2015"));
     }

--- a/src/test/resources/fixtures/list.ttl
+++ b/src/test/resources/fixtures/list.ttl
@@ -1,4 +1,4 @@
-@prefix field: <http://field.openregister.org/field/>.
+@prefix field: <http://field.test.register.gov.uk/field/>.
 
 <http://register.beta.openregister.org/entry/2>
  field:fields <http://field.openregister.org/field/field1> ;

--- a/src/test/resources/fixtures/list.ttl
+++ b/src/test/resources/fixtures/list.ttl
@@ -1,11 +1,11 @@
 @prefix field: <http://field.test.register.gov.uk/field/>.
 
 <http://register.beta.openregister.org/entry/2>
- field:fields <http://field.openregister.org/field/field1> ;
- field:fields <http://field.openregister.org/field/field2> ;
- field:register <http://register.openregister.org/register/value2> ;
+ field:fields <http://field.test.register.gov.uk/field/field1> ;
+ field:fields <http://field.test.register.gov.uk/field/field2> ;
+ field:register <http://register.test.register.gov.uk/register/value2> ;
  field:text "The Entry 2" .
 <http://register.beta.openregister.org/entry/1>
- field:fields <http://field.openregister.org/field/field1> ;
- field:register <http://register.openregister.org/register/value1> ;
+ field:fields <http://field.test.register.gov.uk/field/field1> ;
+ field:register <http://register.test.register.gov.uk/register/value1> ;
  field:text "The Entry 1" .

--- a/src/test/resources/fixtures/single.ttl
+++ b/src/test/resources/fixtures/single.ttl
@@ -1,4 +1,4 @@
-@prefix field: <http://field.openregister.org/field/>.
+@prefix field: <http://field.test.register.gov.uk/field/>.
 
 <http://register.beta.openregister.org/entry/1>
  field:fields <http://field.openregister.org/field/field1> ;

--- a/src/test/resources/fixtures/single.ttl
+++ b/src/test/resources/fixtures/single.ttl
@@ -1,6 +1,6 @@
 @prefix field: <http://field.test.register.gov.uk/field/>.
 
 <http://register.beta.openregister.org/entry/1>
- field:fields <http://field.openregister.org/field/field1> ;
- field:register <http://register.openregister.org/register/value1> ;
+ field:fields <http://field.test.register.gov.uk/field/field1> ;
+ field:register <http://register.test.register.gov.uk/register/value1> ;
  field:text "The Entry 1" .

--- a/src/test/resources/test-app-config.yaml
+++ b/src/test/resources/test-app-config.yaml
@@ -7,6 +7,8 @@ server:
     - type: http
       port: 9001
 
+registerDomain: .test.register.gov.uk
+
 database:
   driverClass: org.postgresql.Driver
   url: PLACEHOLDER

--- a/src/test/resources/test-app-config.yaml
+++ b/src/test/resources/test-app-config.yaml
@@ -7,7 +7,7 @@ server:
     - type: http
       port: 9001
 
-registerDomain: .test.register.gov.uk
+registerDomain: test.register.gov.uk
 
 database:
   driverClass: org.postgresql.Driver


### PR DESCRIPTION
We currently hardcode the `openregister.org` domain in a bunch of different places in the code.  Since we're going to create a new set of registers on a new domain Real Soon Now, we should be able to make this configurable.

This PR finds all hardcoded uses of `openregister.org` and replaces them with a new configuration option instead.

There are a couple of talking points here:
1. To make the registerDomain configuration item available to the ThymeLeafView class, I just added it to the RequestContext class, but it clearly doesn't belong there. I'm happy to try to come up with a better solution, either before or after this is merged.
2. Prior to this PR, there are some places where we construct a hostname based on the hardcoded `openregister.org` suffix, and there are some places where we reuse the hostname that was in the given Host header. This PR only replaces the hardcoded usages with the configuration item, and leaves any place where we reuse the hostname from the Host header untouched.  This is perhaps clearest in the test data for turtle, eg single.ttl:

``` turtle
@prefix field: <http://field.test.register.gov.uk/field/>.

<http://register.beta.openregister.org/entry/1>
 field:fields <http://field.test.register.gov.uk/field/field1> ;
 field:register <http://register.test.register.gov.uk/register/value1> ;
 field:text "The Entry 1" .
```

the `register.beta.openregister.org` line is reused from the Host header, but all of the `test.register.gov.uk` lines are using the configuration item.  (In production, the Host header and the registerDomain header should agree with each other, but that won't always be the case.)

Hopefully these talking points shouldn't block this PR itself from being merged?
