### PR TITLE
Create register resource for register.json

### DIFF
--- a/src/main/java/uk/gov/register/presentation/EntryConverter.java
+++ b/src/main/java/uk/gov/register/presentation/EntryConverter.java
@@ -32,11 +32,17 @@ public class EntryConverter {
     }
 
     public EntryView convert(DbEntry dbEntry) {
-        Iterable<Map.Entry<String, JsonNode>> fields = () -> dbEntry.getContent().getContent().fields();
-        Stream<Map.Entry<String, JsonNode>> fieldStream = StreamSupport.stream(fields.spliterator(), false);
-        return new EntryView(
+        return convert(
                 dbEntry.getSerialNumber(),
                 dbEntry.getContent().getHash(),
+                () -> dbEntry.getContent().getContent().fields());
+    }
+
+    public EntryView convert(int serialNumber, String hash, Iterable<Map.Entry<String, JsonNode>> fields) {
+        Stream<Map.Entry<String, JsonNode>> fieldStream = StreamSupport.stream(fields.spliterator(), false);
+        return new EntryView(
+                serialNumber,
+                hash,
                 requestContext.getRegisterPrimaryKey(),
                 fieldStream.collect(Collectors.toMap(Map.Entry::getKey, this::convert))
         );

--- a/src/main/java/uk/gov/register/presentation/RegisterData.java
+++ b/src/main/java/uk/gov/register/presentation/RegisterData.java
@@ -1,0 +1,40 @@
+package uk.gov.register.presentation;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.dropwizard.jackson.Jackson;
+import uk.gov.register.presentation.config.Register;
+
+import java.util.Map;
+
+public class RegisterData {
+    final ObjectMapper yamlObjectMapper = Jackson.newObjectMapper(new YAMLFactory());
+
+    final int serialNumber;
+    final String hash;
+    final String timestamp;
+    final Map<String, JsonNode> data;
+
+    @JsonCreator
+    public RegisterData(
+            @JsonProperty("serial-number") int serialNumber,
+            @JsonProperty("hash") String hash,
+            @JsonProperty("last-updated") String timestamp,
+            @JsonProperty("entry") Map<String, JsonNode> data) {
+        this.serialNumber = serialNumber;
+        this.hash = hash;
+        this.timestamp = timestamp;
+        this.data = data;
+    }
+
+    public Register getRegister() {
+        return  yamlObjectMapper.convertValue(data, Register.class);
+    }
+
+    public EntryView getEntry(EntryConverter entryConverter) {
+        return entryConverter.convert(serialNumber, hash, data.entrySet());
+    }
+}

--- a/src/main/java/uk/gov/register/presentation/RegisterDetail.java
+++ b/src/main/java/uk/gov/register/presentation/RegisterDetail.java
@@ -1,0 +1,62 @@
+package uk.gov.register.presentation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class RegisterDetail {
+    private final static DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("d MMM uuuu");
+
+    private final String domain;
+    private final int totalRecords;
+    private final int totalEntries;
+    private final int totalItems;
+    private final LocalDateTime lastUpdated;
+    private final EntryView entryView;
+
+    public RegisterDetail(
+            String domain,
+            int totalRecords,
+            int totalEntries,
+            int totalItems,
+            LocalDateTime lastUpdated,
+            EntryView entryView) {
+        this.domain = domain;
+        this.totalRecords = totalRecords;
+        this.totalEntries = totalEntries;
+        this.totalItems = totalItems;
+        this.lastUpdated = lastUpdated;
+        this.entryView = entryView;
+    }
+
+    @JsonProperty("domain")
+    public String getDomain() {
+        return domain;
+    }
+
+    @JsonProperty("last-updated")
+    public String getLastUpdatedTime(){
+        return DATE_TIME_FORMATTER.format(lastUpdated);
+    }
+
+    @JsonProperty("record")
+    public EntryView getEntry() {
+        return entryView;
+    }
+
+    @JsonProperty("total-entries")
+    public int getTotalEntries() {
+        return totalEntries;
+    }
+
+    @JsonProperty("total-items")
+    public int getTotalItems() {
+        return totalItems;
+    }
+
+    @JsonProperty("total-records")
+    public int getTotalRecords(){
+        return totalRecords;
+    }
+}

--- a/src/main/java/uk/gov/register/presentation/config/RegistersConfiguration.java
+++ b/src/main/java/uk/gov/register/presentation/config/RegistersConfiguration.java
@@ -1,12 +1,10 @@
 package uk.gov.register.presentation.config;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.google.common.collect.Lists;
 import io.dropwizard.jackson.Jackson;
+import uk.gov.register.presentation.RegisterData;
 
 import javax.inject.Inject;
 import java.io.IOException;
@@ -16,24 +14,17 @@ import java.util.Objects;
 
 public class RegistersConfiguration {
 
-    private final List<Register> registers;
+    private final List<RegisterData> registers;
 
     @Inject
     public RegistersConfiguration() throws IOException {
         InputStream registersStream = this.getClass().getClassLoader().getResourceAsStream("config/registers.yaml");
         ObjectMapper yamlObjectMapper = Jackson.newObjectMapper(new YAMLFactory());
-        List<RegisterData> rawRegisters = yamlObjectMapper.readValue(registersStream, new TypeReference<List<RegisterData>>() {
+        registers = yamlObjectMapper.readValue(registersStream, new TypeReference<List<RegisterData>>() {
         });
-        registers = Lists.transform(rawRegisters, m -> m.entry);
     }
 
-    public Register getRegister(String registerName) {
-        return registers.stream().filter(f -> Objects.equals(f.registerName, registerName)).findFirst().get();
-    }
-
-    @JsonIgnoreProperties({"hash", "last-updated"})
-    private static class RegisterData{
-        @JsonProperty
-        Register entry;
+    public RegisterData getRegisterData(String registerName) {
+        return registers.stream().filter(f -> Objects.equals(f.getRegister().registerName, registerName)).findFirst().get();
     }
 }

--- a/src/main/java/uk/gov/register/presentation/resource/DataResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/DataResource.java
@@ -6,6 +6,7 @@ import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
 import uk.gov.register.presentation.representations.ExtraMediaType;
 import uk.gov.register.presentation.view.EntryListView;
 import uk.gov.register.presentation.view.ViewFactory;
+import uk.gov.register.thymeleaf.RegisterDetailView;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -73,6 +74,13 @@ public class DataResource {
 
         getFileExtension().ifPresent(ext -> addContentDispositionHeader(requestContext.getRegisterPrimaryKey() + "-records." + ext));
         return viewFactory.getRecordsView(queryDAO.getLatestEntriesOfRecords(pagination.pageSize(), pagination.offset()), pagination);
+    }
+
+    @GET
+    @Path("/register")
+    @Produces({MediaType.APPLICATION_JSON})
+    public RegisterDetailView getRegisterDetail() {
+        return viewFactory.registerDetailView(queryDAO.getTotalRecords(), queryDAO.getTotalEntries(), queryDAO.getTotalEntries(), queryDAO.getLastUpdatedTime());
     }
 
     private Optional<String> getFileExtension() {

--- a/src/main/java/uk/gov/register/presentation/resource/HomePageResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/HomePageResource.java
@@ -25,7 +25,7 @@ public class HomePageResource {
     @GET
     @Produces({ExtraMediaType.TEXT_HTML})
     public View home() {
-        return viewFactory.homePageView(recentEntryIndexQueryDAO.getTotalRecords(), recentEntryIndexQueryDAO.getLastUpdatedTime());
+        return viewFactory.homePageView(recentEntryIndexQueryDAO.getTotalRecords(), recentEntryIndexQueryDAO.getTotalEntries(), recentEntryIndexQueryDAO.getLastUpdatedTime());
     }
 
     @GET

--- a/src/main/java/uk/gov/register/presentation/resource/RequestContext.java
+++ b/src/main/java/uk/gov/register/presentation/resource/RequestContext.java
@@ -1,6 +1,7 @@
 package uk.gov.register.presentation.resource;
 
 import org.jvnet.hk2.annotations.Service;
+import uk.gov.register.presentation.RegisterData;
 import uk.gov.register.presentation.RegisterNameExtractor;
 import uk.gov.register.presentation.config.Register;
 import uk.gov.register.presentation.config.RegisterDomainConfiguration;
@@ -59,7 +60,11 @@ public class RequestContext {
     }
 
     public Register getRegister() {
-        return registersConfiguration.getRegister(getRegisterPrimaryKey());
+        return getRegisterData().getRegister();
+    }
+
+    public RegisterData getRegisterData() {
+        return registersConfiguration.getRegisterData(getRegisterPrimaryKey());
     }
 
     public String getRegisterDomain() {

--- a/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
+++ b/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
@@ -79,8 +79,8 @@ public class ViewFactory {
         return new BadRequestExceptionView(requestContext, e);
     }
 
-    public HomePageView homePageView(int totalRecords, LocalDateTime lastUpdated) {
-        return new HomePageView(getCustodian(), getBranding(), requestContext, totalRecords, lastUpdated, registerDomain);
+    public HomePageView homePageView(int totalRecords, int totalEntries, LocalDateTime lastUpdated) {
+        return new HomePageView(getCustodian(), getBranding(), requestContext, totalRecords, totalEntries, lastUpdated, registerDomain);
     }
 
     public ListVersionView listVersionView(List<Version> versions) throws Exception {

--- a/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
+++ b/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
@@ -13,6 +13,7 @@ import uk.gov.register.presentation.resource.Pagination;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.register.thymeleaf.BadRequestExceptionView;
 import uk.gov.register.thymeleaf.HomePageView;
+import uk.gov.register.thymeleaf.RegisterDetailView;
 import uk.gov.register.thymeleaf.ThymeleafView;
 
 import javax.inject.Inject;
@@ -81,6 +82,10 @@ public class ViewFactory {
 
     public HomePageView homePageView(int totalRecords, int totalEntries, LocalDateTime lastUpdated) {
         return new HomePageView(getCustodian(), getBranding(), requestContext, totalRecords, totalEntries, lastUpdated, registerDomain);
+    }
+
+    public RegisterDetailView registerDetailView(int totalRecords, int totalEntries, int totalItems, LocalDateTime lastUpdated) {
+        return new RegisterDetailView(getCustodian(), getBranding(), requestContext, entryConverter, totalRecords, totalEntries, totalItems, lastUpdated);
     }
 
     public ListVersionView listVersionView(List<Version> versions) throws Exception {

--- a/src/main/java/uk/gov/register/thymeleaf/HomePageView.java
+++ b/src/main/java/uk/gov/register/thymeleaf/HomePageView.java
@@ -17,6 +17,7 @@ public class HomePageView extends AttributionView {
 
     private final LocalDateTime lastUpdated;
     private final int totalRecords;
+    private final int totalEntries;
     private final String registerDomain;
 
     public HomePageView(
@@ -24,11 +25,13 @@ public class HomePageView extends AttributionView {
             Optional<GovukOrganisation.Details> custodianBranding,
             RequestContext requestContext,
             int totalRecords,
+            int totalEntries,
             LocalDateTime lastUpdated,
             String registerDomain
     ) {
         super(requestContext, custodian, custodianBranding, "home.html");
         this.totalRecords = totalRecords;
+        this.totalEntries = totalEntries;
         this.lastUpdated = lastUpdated;
         this.registerDomain = registerDomain;
     }
@@ -41,6 +44,11 @@ public class HomePageView extends AttributionView {
     @SuppressWarnings("unused, used from template")
     public int getTotalRecords(){
         return totalRecords;
+    }
+
+    @SuppressWarnings("unused, used from template")
+    public int getTotalEntries() {
+        return totalEntries;
     }
 
     @SuppressWarnings("unused, used from template")

--- a/src/main/java/uk/gov/register/thymeleaf/RegisterDetailView.java
+++ b/src/main/java/uk/gov/register/thymeleaf/RegisterDetailView.java
@@ -1,0 +1,48 @@
+package uk.gov.register.thymeleaf;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import uk.gov.organisation.client.GovukOrganisation;
+import uk.gov.register.presentation.EntryConverter;
+import uk.gov.register.presentation.RegisterDetail;
+import uk.gov.register.presentation.config.PublicBody;
+import uk.gov.register.presentation.resource.RequestContext;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public class RegisterDetailView extends AttributionView {
+    private final EntryConverter entryConverter;
+
+    private final int totalRecords;
+    private final int totalEntries;
+    private final int totalItems;
+    private final LocalDateTime lastUpdated;
+
+    public RegisterDetailView(
+            PublicBody custodian,
+            Optional<GovukOrganisation.Details> custodianBranding,
+            RequestContext requestContext,
+            EntryConverter entryConverter,
+            int totalRecords,
+            int totalEntries,
+            int totalItems,
+            LocalDateTime lastUpdated) {
+        super(requestContext, custodian, custodianBranding, "");
+        this.entryConverter = entryConverter;
+        this.totalRecords = totalRecords;
+        this.totalEntries = totalEntries;
+        this.totalItems = totalItems;
+        this.lastUpdated = lastUpdated;
+    }
+
+    @JsonValue
+    public RegisterDetail getRegisterDetail() {
+        return new RegisterDetail(
+                ".openregister.org",
+                totalRecords,
+                totalEntries,
+                totalItems,
+                lastUpdated,
+                getRegisterEntryView(entryConverter));
+    }
+}

--- a/src/main/java/uk/gov/register/thymeleaf/ThymeleafView.java
+++ b/src/main/java/uk/gov/register/thymeleaf/ThymeleafView.java
@@ -2,6 +2,8 @@ package uk.gov.register.thymeleaf;
 
 import io.dropwizard.views.View;
 import org.apache.commons.lang3.StringUtils;
+import uk.gov.register.presentation.EntryConverter;
+import uk.gov.register.presentation.EntryView;
 import uk.gov.register.presentation.config.Register;
 import uk.gov.register.presentation.resource.RequestContext;
 
@@ -48,6 +50,10 @@ public class ThymeleafView extends View {
 
     public Register getRegister() {
         return requestContext.getRegister();
+    }
+
+    public EntryView getRegisterEntryView(EntryConverter entryConverter) {
+        return requestContext.getRegisterData().getEntry(entryConverter);
     }
 
     public String getRegisterDomain() {

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -15,6 +15,8 @@
                 <dd><th:block th:include="main.html :: organisation(${custodian}, ${branding})"></th:block></dd>
                 <dt>Total records:</dt>
                 <dd><a href="/records" th:text="${totalRecords}">Total records</a></dd>
+                <dt>Total entries:</dt>
+                <dd><a href="/entries" th:text="${totalEntries}">Total entries</a></dd>
                 <dt>Last updated:</dt>
                 <dd><a href="/entries" th:text="${lastUpdatedTime}">Last updated</a></dd>
             </dl>

--- a/src/test/java/uk/gov/register/thymeleaf/HomePageViewTest.java
+++ b/src/test/java/uk/gov/register/thymeleaf/HomePageViewTest.java
@@ -22,7 +22,7 @@ public class HomePageViewTest {
 
     @Test
     public void getRegisterText_rendersRegisterTextAsMarkdown() throws Exception {
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, null, "openregister.org");
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, null, "openregister.org");
 
         String registerText = "foo *bar* [baz](/quux)";
         when(mockRequestContext.getRegister()).thenReturn(new Register("", Sets.newSet(), "", "", registerText));
@@ -36,7 +36,7 @@ public class HomePageViewTest {
     public void getLastUpdatedTime_formatsTheLocalDateTimeToUKDateTimeFormat() {
         LocalDateTime localDateTime = LocalDateTime.of(2015, 9, 11, 13, 17, 59, 543);
 
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, localDateTime, "openregister.org");
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, localDateTime, "openregister.org");
 
         assertThat(homePageView.getLastUpdatedTime(), equalTo("11 Sep 2015"));
     }


### PR DESCRIPTION
Added Total Entries to the HomePage for a register.

Created a /register resource which currently only returns json format. At some point we might want to merge the RegisterResourceView with the HomePageView if they are intended to display the same information. At the moment they are separate views.

Refactored the RegisterConfig and Register objects to retrieve the register entry as an EntryView, so that all representations of an entry remain consistent, whether just the entry or an entry nested in a register resource.

Still need to change last-updated property to return in sensible format. Also need to remove hardcoded registerDomain and reuse recent change made my @philandstuff to make registerDomain configurable.
