### PR TITLE
Return last-updated for register from leaf_input

### DIFF
--- a/src/main/java/uk/gov/register/presentation/RegisterDetail.java
+++ b/src/main/java/uk/gov/register/presentation/RegisterDetail.java
@@ -2,15 +2,17 @@ package uk.gov.register.presentation;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 public class RegisterDetail {
+    private final static DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ISO_INSTANT;
 
     private final String domain;
     private final int totalRecords;
     private final int totalEntries;
     private final int totalItems;
-    private final LocalDateTime lastUpdated;
+    private final Instant lastUpdated;
     private final EntryView entryView;
 
     public RegisterDetail(
@@ -18,7 +20,7 @@ public class RegisterDetail {
             int totalRecords,
             int totalEntries,
             int totalItems,
-            LocalDateTime lastUpdated,
+            Instant lastUpdated,
             EntryView entryView) {
         this.domain = domain;
         this.totalRecords = totalRecords;
@@ -33,6 +35,7 @@ public class RegisterDetail {
         return domain;
     }
 
+    @SuppressWarnings("unused, used from template")
     @JsonProperty("last-updated")
     public String getLastUpdatedTime(){
         return lastUpdated.toString();
@@ -43,16 +46,19 @@ public class RegisterDetail {
         return entryView;
     }
 
+    @SuppressWarnings("unused, used from template")
     @JsonProperty("total-entries")
     public int getTotalEntries() {
         return totalEntries;
     }
 
+    @SuppressWarnings("unused, used from template")
     @JsonProperty("total-items")
     public int getTotalItems() {
         return totalItems;
     }
 
+    @SuppressWarnings("unused, used from template")
     @JsonProperty("total-records")
     public int getTotalRecords(){
         return totalRecords;

--- a/src/main/java/uk/gov/register/presentation/dao/RecentEntryIndexQueryDAO.java
+++ b/src/main/java/uk/gov/register/presentation/dao/RecentEntryIndexQueryDAO.java
@@ -11,9 +11,10 @@ import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
 import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
 import uk.gov.register.presentation.DbEntry;
 import uk.gov.register.presentation.mapper.EntryMapper;
+import uk.gov.register.proofs.ct.CTEntryLeaf;
 
 import java.sql.SQLException;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -40,6 +41,9 @@ public abstract class RecentEntryIndexQueryDAO {
     @SingleValueResult(DbEntry.class)
     public abstract Optional<DbEntry> findEntryBySerialNumber(@Bind("serial") long serial);
 
+    @SqlQuery("SELECT leaf_input FROM ordered_entry_index ORDER BY serial_number DESC LIMIT 1")
+    public abstract String getLatestTreeInput();
+
     @SqlQuery("SELECT serial_number,entry,leaf_input FROM (" +
             "SELECT idx.serial_number, idx.entry, idx.leaf_input FROM ordered_entry_index idx, current_keys ck " +
             "WHERE  entry @> :content " +
@@ -61,9 +65,6 @@ public abstract class RecentEntryIndexQueryDAO {
     @SqlQuery("SELECT count FROM total_records")
     public abstract int getTotalRecords();
 
-    @SqlQuery("SELECT last_updated FROM total_entries")
-    public abstract LocalDateTime getLastUpdatedTime();
-
     public List<DbEntry> findAllEntriesByKeyValue(String key, String value) throws Exception {
         Object entry = ImmutableMap.of("entry", ImmutableMap.of(key, value));
         return findAllEntriesByJsonContent(writePGObject(entry));
@@ -72,6 +73,10 @@ public abstract class RecentEntryIndexQueryDAO {
     public List<DbEntry> findLatestEntriesOfRecordsByKeyValue(String key, String value) throws Exception {
         Object entry = ImmutableMap.of("entry", ImmutableMap.of(key, value));
         return findLatestEntriesOfRecordsByJsonContent(writePGObject(entry));
+    }
+
+    public Instant getLastUpdatedTime() {
+        return Instant.ofEpochMilli(new CTEntryLeaf(getLatestTreeInput()).getTimestamp());
     }
 
     private PGobject writePGObject(Object value) throws JsonProcessingException, SQLException {

--- a/src/main/java/uk/gov/register/presentation/dao/RecentEntryIndexQueryDAO.java
+++ b/src/main/java/uk/gov/register/presentation/dao/RecentEntryIndexQueryDAO.java
@@ -42,7 +42,7 @@ public abstract class RecentEntryIndexQueryDAO {
     public abstract Optional<DbEntry> findEntryBySerialNumber(@Bind("serial") long serial);
 
     @SqlQuery("SELECT leaf_input FROM ordered_entry_index ORDER BY serial_number DESC LIMIT 1")
-    public abstract String getLatestTreeInput();
+    public abstract String getLatestLeafInput();
 
     @SqlQuery("SELECT serial_number,entry,leaf_input FROM (" +
             "SELECT idx.serial_number, idx.entry, idx.leaf_input FROM ordered_entry_index idx, current_keys ck " +
@@ -76,7 +76,7 @@ public abstract class RecentEntryIndexQueryDAO {
     }
 
     public Instant getLastUpdatedTime() {
-        return Instant.ofEpochMilli(new CTEntryLeaf(getLatestTreeInput()).getTimestamp());
+        return Instant.ofEpochMilli(new CTEntryLeaf(getLatestLeafInput()).getTimestamp());
     }
 
     private PGobject writePGObject(Object value) throws JsonProcessingException, SQLException {

--- a/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
+++ b/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
@@ -18,7 +18,7 @@ import uk.gov.register.thymeleaf.ThymeleafView;
 
 import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -80,11 +80,11 @@ public class ViewFactory {
         return new BadRequestExceptionView(requestContext, e);
     }
 
-    public HomePageView homePageView(int totalRecords, int totalEntries, LocalDateTime lastUpdated) {
+    public HomePageView homePageView(int totalRecords, int totalEntries, Instant lastUpdated) {
         return new HomePageView(getCustodian(), getBranding(), requestContext, totalRecords, totalEntries, lastUpdated, registerDomain);
     }
 
-    public RegisterDetailView registerDetailView(int totalRecords, int totalEntries, int totalItems, LocalDateTime lastUpdated) {
+    public RegisterDetailView registerDetailView(int totalRecords, int totalEntries, int totalItems, Instant lastUpdated) {
         return new RegisterDetailView(getCustodian(), getBranding(), requestContext, entryConverter, totalRecords, totalEntries, totalItems, lastUpdated);
     }
 

--- a/src/main/java/uk/gov/register/proofs/ct/CTEntryLeaf.java
+++ b/src/main/java/uk/gov/register/proofs/ct/CTEntryLeaf.java
@@ -1,0 +1,79 @@
+package uk.gov.register.proofs.ct;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Base64;
+
+@SuppressWarnings({"FieldCanBeLocal", "unused"})
+
+@JsonIgnoreProperties({"extra_data"})
+public class CTEntryLeaf {
+    private final byte version;
+
+    private final byte merkleLeafType;
+
+    private final byte[] timetamp;
+
+    private final byte[] entryType;
+
+    private final int contentLength;
+
+    private final byte[] payload;
+
+    private final byte[] sctExtension;
+
+    private final String leafInput;
+
+    @JsonCreator
+    public CTEntryLeaf(@JsonProperty("leaf_input") String leafInput) {
+        this.leafInput = leafInput;
+
+        byte[] decodedBytes = Base64.getDecoder().decode(leafInput);
+
+        int decodeBytesLength = decodedBytes.length;
+
+        //first byte is version
+        version = decodedBytes[0];
+
+        //second byte is leaftype
+        merkleLeafType = decodedBytes[1];
+
+        //next 8 bytes are timestamp
+        timetamp = Arrays.copyOfRange(decodedBytes, 2, 10);
+
+        //bytes at position 10 and 11 are entryType
+        entryType = new byte[]{decodedBytes[10], decodedBytes[11]};
+
+        //bytes at position 12, 13 and 14 are contentLength
+        contentLength = new BigInteger(new byte[]{decodedBytes[12], decodedBytes[13], decodedBytes[14]}).intValue();
+
+        //last two bytes in array are sctExtension so from byte 15 till (bytes array length -2) is payload
+        payload = Arrays.copyOfRange(decodedBytes, 15, 15 + contentLength);
+
+        sctExtension = new byte[]{decodedBytes[decodeBytesLength - 2], decodedBytes[decodeBytesLength - 1]};
+    }
+
+    public byte[] getPayload() {
+        return payload;
+    }
+
+    public String getLeafInput() {
+        return leafInput;
+    }
+
+    public long getTimestamp() {
+        ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+        buffer.put(timetamp);
+        buffer.flip();
+        return buffer.getLong();
+    }
+
+    public int getContentLength() {
+        return contentLength;
+    }
+}

--- a/src/main/java/uk/gov/register/thymeleaf/HomePageView.java
+++ b/src/main/java/uk/gov/register/thymeleaf/HomePageView.java
@@ -6,16 +6,17 @@ import uk.gov.register.presentation.config.PublicBody;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.organisation.client.GovukOrganisation;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
 public class HomePageView extends AttributionView {
-    private final static DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("d MMM uuuu");
+    private final static DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("d MMM uuuu").withZone(ZoneId.of("UTC"));
 
     private final MarkdownProcessor markdownProcessor = new MarkdownProcessor();
 
-    private final LocalDateTime lastUpdated;
+    private final Instant lastUpdated;
     private final int totalRecords;
     private final int totalEntries;
     private final String registerDomain;
@@ -26,7 +27,7 @@ public class HomePageView extends AttributionView {
             RequestContext requestContext,
             int totalRecords,
             int totalEntries,
-            LocalDateTime lastUpdated,
+            Instant lastUpdated,
             String registerDomain
     ) {
         super(requestContext, custodian, custodianBranding, "home.html");

--- a/src/main/java/uk/gov/register/thymeleaf/RegisterDetailView.java
+++ b/src/main/java/uk/gov/register/thymeleaf/RegisterDetailView.java
@@ -7,7 +7,7 @@ import uk.gov.register.presentation.RegisterDetail;
 import uk.gov.register.presentation.config.PublicBody;
 import uk.gov.register.presentation.resource.RequestContext;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Optional;
 
 public class RegisterDetailView extends AttributionView {
@@ -16,7 +16,7 @@ public class RegisterDetailView extends AttributionView {
     private final int totalRecords;
     private final int totalEntries;
     private final int totalItems;
-    private final LocalDateTime lastUpdated;
+    private final Instant lastUpdated;
 
     public RegisterDetailView(
             PublicBody custodian,
@@ -26,7 +26,7 @@ public class RegisterDetailView extends AttributionView {
             int totalRecords,
             int totalEntries,
             int totalItems,
-            LocalDateTime lastUpdated) {
+            Instant lastUpdated) {
         super(requestContext, custodian, custodianBranding, "");
         this.entryConverter = entryConverter;
         this.totalRecords = totalRecords;

--- a/src/test/java/uk/gov/register/thymeleaf/HomePageViewTest.java
+++ b/src/test/java/uk/gov/register/thymeleaf/HomePageViewTest.java
@@ -8,7 +8,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.register.presentation.config.Register;
 import uk.gov.register.presentation.resource.RequestContext;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
@@ -34,9 +36,9 @@ public class HomePageViewTest {
 
     @Test
     public void getLastUpdatedTime_formatsTheLocalDateTimeToUKDateTimeFormat() {
-        LocalDateTime localDateTime = LocalDateTime.of(2015, 9, 11, 13, 17, 59, 543);
+        Instant instant = LocalDateTime.of(2015, 9, 11, 13, 17, 59, 543).toInstant(ZoneOffset.UTC);
 
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, localDateTime, "openregister.org");
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, instant, "openregister.org");
 
         assertThat(homePageView.getLastUpdatedTime(), equalTo("11 Sep 2015"));
     }


### PR DESCRIPTION
This retrieves the leaf_input from the ordered_entry_index table for the row with the greatest serial_number. The getLastUpdated() method is changed to decode the leaf_input and return the timestamp. This timestamp is stored in the views as an Instant such that it is possible to display the UTC timezone when it is formatted as a date-time string in the json formats.

Also changed the RegisterResourceFunctionalTest to check that the timestamp is retrieved from the database correctly. The DBSupport class is changed to return the timestamp of the item added to the ordered_entry_index table with the greatest serial_number, such that it can be compared to the last-updated property of the /register.json returned.
