### PR TITLE
Display empty string when no leaf_input exists

### DIFF
--- a/src/main/java/uk/gov/register/presentation/RegisterDetail.java
+++ b/src/main/java/uk/gov/register/presentation/RegisterDetail.java
@@ -3,16 +3,14 @@ package uk.gov.register.presentation;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.Instant;
-import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 
 public class RegisterDetail {
-    private final static DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ISO_INSTANT;
-
     private final String domain;
     private final int totalRecords;
     private final int totalEntries;
     private final int totalItems;
-    private final Instant lastUpdated;
+    private final Optional<Instant> lastUpdated;
     private final EntryView entryView;
 
     public RegisterDetail(
@@ -20,7 +18,7 @@ public class RegisterDetail {
             int totalRecords,
             int totalEntries,
             int totalItems,
-            Instant lastUpdated,
+            Optional<Instant> lastUpdated,
             EntryView entryView) {
         this.domain = domain;
         this.totalRecords = totalRecords;
@@ -37,8 +35,8 @@ public class RegisterDetail {
 
     @SuppressWarnings("unused, used from template")
     @JsonProperty("last-updated")
-    public String getLastUpdatedTime(){
-        return lastUpdated.toString();
+    public String getLastUpdatedTime() {
+        return lastUpdated.map(Instant::toString).orElse("");
     }
 
     @JsonProperty("record")
@@ -60,7 +58,7 @@ public class RegisterDetail {
 
     @SuppressWarnings("unused, used from template")
     @JsonProperty("total-records")
-    public int getTotalRecords(){
+    public int getTotalRecords() {
         return totalRecords;
     }
 }

--- a/src/main/java/uk/gov/register/presentation/resource/DataResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/DataResource.java
@@ -48,11 +48,12 @@ public class DataResource {
         List<DbEntry> entries = queryDAO.getAllEntriesNoPagination();
         SignedTreeHead sth = signedTreeHeadQueryDAO.get();
 
-        RegisterDetail registerDetail = viewFactory.registerDetailView(queryDAO.getTotalRecords(),
+        RegisterDetail registerDetail = viewFactory.registerDetailView(
+                queryDAO.getTotalRecords(),
                 queryDAO.getTotalEntries(),
                 queryDAO.getTotalEntries(),
-                queryDAO.getLastUpdatedTime())
-                .getRegisterDetail();
+                queryDAO.getLastUpdatedTime()
+        ).getRegisterDetail();
 
         return Response
                 .ok(new ArchiveCreator().create(registerDetail, entries, sth))

--- a/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
+++ b/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
@@ -80,11 +80,11 @@ public class ViewFactory {
         return new BadRequestExceptionView(requestContext, e);
     }
 
-    public HomePageView homePageView(int totalRecords, int totalEntries, Instant lastUpdated) {
+    public HomePageView homePageView(int totalRecords, int totalEntries, Optional<Instant> lastUpdated) {
         return new HomePageView(getCustodian(), getBranding(), requestContext, totalRecords, totalEntries, lastUpdated, registerDomain);
     }
 
-    public RegisterDetailView registerDetailView(int totalRecords, int totalEntries, int totalItems, Instant lastUpdated) {
+    public RegisterDetailView registerDetailView(int totalRecords, int totalEntries, int totalItems, Optional<Instant> lastUpdated) {
         return new RegisterDetailView(getCustodian(), getBranding(), requestContext, entryConverter, totalRecords, totalEntries, totalItems, lastUpdated);
     }
 

--- a/src/main/java/uk/gov/register/thymeleaf/HomePageView.java
+++ b/src/main/java/uk/gov/register/thymeleaf/HomePageView.java
@@ -16,7 +16,7 @@ public class HomePageView extends AttributionView {
 
     private final MarkdownProcessor markdownProcessor = new MarkdownProcessor();
 
-    private final Instant lastUpdated;
+    private final Optional<Instant> lastUpdated;
     private final int totalRecords;
     private final int totalEntries;
     private final String registerDomain;
@@ -27,7 +27,7 @@ public class HomePageView extends AttributionView {
             RequestContext requestContext,
             int totalRecords,
             int totalEntries,
-            Instant lastUpdated,
+            Optional<Instant> lastUpdated,
             String registerDomain
     ) {
         super(requestContext, custodian, custodianBranding, "home.html");
@@ -43,7 +43,7 @@ public class HomePageView extends AttributionView {
     }
 
     @SuppressWarnings("unused, used from template")
-    public int getTotalRecords(){
+    public int getTotalRecords() {
         return totalRecords;
     }
 
@@ -53,12 +53,12 @@ public class HomePageView extends AttributionView {
     }
 
     @SuppressWarnings("unused, used from template")
-    public String getLastUpdatedTime(){
-        return DATE_TIME_FORMATTER.format(lastUpdated);
+    public String getLastUpdatedTime() {
+        return lastUpdated.map(DATE_TIME_FORMATTER::format).orElse("");
     }
 
     @SuppressWarnings("unused, used from template")
-    public String getLinkToRegisterRegister(){
+    public String getLinkToRegisterRegister() {
         return new LinkValue("register", registerDomain, getRegisterId()).link();
     }
 }

--- a/src/main/java/uk/gov/register/thymeleaf/RegisterDetailView.java
+++ b/src/main/java/uk/gov/register/thymeleaf/RegisterDetailView.java
@@ -16,7 +16,7 @@ public class RegisterDetailView extends AttributionView {
     private final int totalRecords;
     private final int totalEntries;
     private final int totalItems;
-    private final Instant lastUpdated;
+    private final Optional<Instant> lastUpdated;
 
     public RegisterDetailView(
             PublicBody custodian,
@@ -26,7 +26,7 @@ public class RegisterDetailView extends AttributionView {
             int totalRecords,
             int totalEntries,
             int totalItems,
-            Instant lastUpdated) {
+            Optional<Instant> lastUpdated) {
         super(requestContext, custodian, custodianBranding, "");
         this.entryConverter = entryConverter;
         this.totalRecords = totalRecords;

--- a/src/test/java/uk/gov/register/presentation/RegisterDetailTest.java
+++ b/src/test/java/uk/gov/register/presentation/RegisterDetailTest.java
@@ -1,0 +1,23 @@
+package uk.gov.register.presentation;
+
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class RegisterDetailTest {
+    @Test
+    public void getLastUpdatedTime_returnsTheEmptyStringIfNoTimeStampExists() {
+        RegisterDetail registerDetail = new RegisterDetail("", 0, 0, 0, Optional.<Instant>empty(), null);
+        assertThat(registerDetail.getLastUpdatedTime(), equalTo(""));
+    }
+
+    @Test
+    public void getLastUpdatedTime_returnsTheTimestampIfExists() {
+        RegisterDetail registerDetail = new RegisterDetail("", 0, 0, 0, Optional.of(Instant.ofEpochMilli(1411111111)), null);
+        assertThat(registerDetail.getLastUpdatedTime(), equalTo("1970-01-17T07:58:31.111Z"));
+    }
+}

--- a/src/test/java/uk/gov/register/presentation/functional/HomePageFunctionalTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/HomePageFunctionalTest.java
@@ -1,0 +1,26 @@
+package uk.gov.register.presentation.functional;
+
+import org.junit.Test;
+import uk.gov.register.presentation.functional.testSupport.DBSupport;
+
+import javax.ws.rs.core.Response;
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class HomePageFunctionalTest extends FunctionalTestBase {
+    @Test
+    public void homePageIsAvailableWhenNoDataInRegister() {
+        Response response = getRequest("/");
+        assertThat(response.getStatus(), equalTo(200));
+    }
+
+    @Test
+    public void homePageIsAvailableWhenLatestEntryHasNullLeafInput() throws Throwable {
+        DBSupport.publishMessagesWithoutLeafInput("address", Collections.singletonList("{\"address\":\"1234\"}"));
+        Response response = getRequest("/");
+        assertThat(response.getStatus(), equalTo(200));
+        cleanDatabaseRule.before();
+    }
+}

--- a/src/test/java/uk/gov/register/presentation/functional/testSupport/CleanDatabaseRule.java
+++ b/src/test/java/uk/gov/register/presentation/functional/testSupport/CleanDatabaseRule.java
@@ -2,7 +2,9 @@ package uk.gov.register.presentation.functional.testSupport;
 
 import org.junit.rules.ExternalResource;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
 
 public class CleanDatabaseRule extends ExternalResource {
     private final String pgUser;
@@ -18,22 +20,24 @@ public class CleanDatabaseRule extends ExternalResource {
     @Override
     public void before() throws Throwable {
         try (Connection connection = DriverManager.getConnection(pgUrl, pgUser, "")) {
-            connection.prepareStatement("DROP TABLE IF EXISTS " + tableName).execute();
-            connection.prepareStatement("CREATE TABLE " + tableName + " (SERIAL_NUMBER INTEGER PRIMARY KEY, ENTRY JSONB, leaf_input varchar)").execute();
+            try(Statement statement = connection.createStatement()){
+                statement.execute("DROP TABLE IF EXISTS " + tableName);
+                statement.execute("CREATE TABLE " + tableName + " (SERIAL_NUMBER INTEGER PRIMARY KEY, ENTRY JSONB, leaf_input varchar)");
 
-            connection.prepareStatement("DROP TABLE IF EXISTS total_entries").execute();
-            connection.prepareStatement("CREATE TABLE IF NOT EXISTS   total_entries   (count INTEGER, last_updated TIMESTAMP WITHOUT TIME ZONE DEFAULT now())").execute();
-            connection.prepareStatement("INSERT INTO TOTAL_ENTRIES(COUNT) VALUES(0)").execute();
+                statement.execute("DROP TABLE IF EXISTS total_entries");
+                statement.execute("CREATE TABLE IF NOT EXISTS   total_entries   (count INTEGER, last_updated TIMESTAMP WITHOUT TIME ZONE DEFAULT now())");
+                statement.execute("INSERT INTO TOTAL_ENTRIES(COUNT) VALUES(0)");
 
-            connection.prepareStatement("DROP TABLE IF EXISTS CURRENT_KEYS").execute();
-            connection.prepareStatement("CREATE TABLE CURRENT_KEYS (SERIAL_NUMBER INTEGER PRIMARY KEY, KEY VARCHAR UNIQUE)").execute();
+                statement.execute("DROP TABLE IF EXISTS CURRENT_KEYS");
+                statement.execute("CREATE TABLE CURRENT_KEYS (SERIAL_NUMBER INTEGER PRIMARY KEY, KEY VARCHAR UNIQUE)");
 
-            connection.prepareStatement("DROP TABLE IF EXISTS TOTAL_RECORDS").execute();
-            connection.prepareStatement("CREATE TABLE TOTAL_RECORDS (COUNT INTEGER)").execute();
-            connection.prepareStatement("INSERT INTO TOTAL_RECORDS(COUNT) VALUES(0)").execute();
+                statement.execute("DROP TABLE IF EXISTS TOTAL_RECORDS");
+                statement.execute("CREATE TABLE TOTAL_RECORDS (COUNT INTEGER)");
+                statement.execute("INSERT INTO TOTAL_RECORDS(COUNT) VALUES(0)");
 
-            connection.prepareStatement("DROP TABLE IF EXISTS STH").execute();
-            connection.prepareStatement("create table sth (tree_size integer, timestamp bigint, tree_head_signature varchar, sha256_root_hash varchar)").execute();
+                statement.execute("DROP TABLE IF EXISTS STH");
+                statement.execute("create table sth (tree_size integer, timestamp bigint, tree_head_signature varchar, sha256_root_hash varchar)");
+            }
         }
     }
 }

--- a/src/test/java/uk/gov/register/thymeleaf/HomePageViewTest.java
+++ b/src/test/java/uk/gov/register/thymeleaf/HomePageViewTest.java
@@ -11,6 +11,7 @@ import uk.gov.register.presentation.resource.RequestContext;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.Optional;
 
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
@@ -38,7 +39,7 @@ public class HomePageViewTest {
     public void getLastUpdatedTime_formatsTheLocalDateTimeToUKDateTimeFormat() {
         Instant instant = LocalDateTime.of(2015, 9, 11, 13, 17, 59, 543).toInstant(ZoneOffset.UTC);
 
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, instant, "openregister.org");
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.of(instant), "openregister.org");
 
         assertThat(homePageView.getLastUpdatedTime(), equalTo("11 Sep 2015"));
     }

--- a/src/test/resources/test-app-config.yaml
+++ b/src/test/resources/test-app-config.yaml
@@ -15,3 +15,11 @@ database:
   user: postgres
   properties:
     charSet: UTF-8
+
+  #db connection properties
+  initialSize: 1
+  minSize: 1
+  maxSize: 2
+
+  properties:
+    charSet: UTF-8


### PR DESCRIPTION
home page displays 500 error when no entries available in database. It was happening because leaf_input column has no value and we are extracting timestamp. 

Changes in PR displays empty string for timestamp when leaf_input value not present.
