### PR TITLE
Move view classes to view package.

### DIFF
--- a/src/main/java/uk/gov/register/presentation/resource/DataResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/DataResource.java
@@ -11,7 +11,7 @@ import uk.gov.register.presentation.representations.ExtraMediaType;
 import uk.gov.register.presentation.view.EntryListView;
 import uk.gov.register.presentation.view.ViewFactory;
 import uk.gov.register.proofs.ct.SignedTreeHead;
-import uk.gov.register.thymeleaf.RegisterDetailView;
+import uk.gov.register.presentation.view.RegisterDetailView;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;

--- a/src/main/java/uk/gov/register/presentation/resource/RegisterProofResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/RegisterProofResource.java
@@ -2,7 +2,7 @@ package uk.gov.register.presentation.resource;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import uk.gov.register.presentation.dao.SignedTreeHeadQueryDAO;
-import uk.gov.register.thymeleaf.RegisterProofView;
+import uk.gov.register.presentation.view.RegisterProofView;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;

--- a/src/main/java/uk/gov/register/presentation/view/AttributionView.java
+++ b/src/main/java/uk/gov/register/presentation/view/AttributionView.java
@@ -1,8 +1,9 @@
-package uk.gov.register.thymeleaf;
+package uk.gov.register.presentation.view;
 
 import uk.gov.register.presentation.config.PublicBody;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.organisation.client.GovukOrganisation;
+import uk.gov.register.thymeleaf.ThymeleafView;
 
 import java.util.Optional;
 

--- a/src/main/java/uk/gov/register/presentation/view/BadRequestExceptionView.java
+++ b/src/main/java/uk/gov/register/presentation/view/BadRequestExceptionView.java
@@ -1,6 +1,7 @@
-package uk.gov.register.thymeleaf;
+package uk.gov.register.presentation.view;
 
 import uk.gov.register.presentation.resource.RequestContext;
+import uk.gov.register.thymeleaf.ThymeleafView;
 
 import javax.ws.rs.BadRequestException;
 

--- a/src/main/java/uk/gov/register/presentation/view/EntryListView.java
+++ b/src/main/java/uk/gov/register/presentation/view/EntryListView.java
@@ -6,7 +6,6 @@ import uk.gov.register.presentation.EntryView;
 import uk.gov.register.presentation.config.PublicBody;
 import uk.gov.register.presentation.resource.Pagination;
 import uk.gov.register.presentation.resource.RequestContext;
-import uk.gov.register.thymeleaf.AttributionView;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/uk/gov/register/presentation/view/HomePageView.java
+++ b/src/main/java/uk/gov/register/presentation/view/HomePageView.java
@@ -1,4 +1,4 @@
-package uk.gov.register.thymeleaf;
+package uk.gov.register.presentation.view;
 
 import org.markdownj.MarkdownProcessor;
 import uk.gov.register.presentation.LinkValue;

--- a/src/main/java/uk/gov/register/presentation/view/ListVersionView.java
+++ b/src/main/java/uk/gov/register/presentation/view/ListVersionView.java
@@ -5,7 +5,6 @@ import uk.gov.organisation.client.GovukOrganisation;
 import uk.gov.register.presentation.Version;
 import uk.gov.register.presentation.config.PublicBody;
 import uk.gov.register.presentation.resource.RequestContext;
-import uk.gov.register.thymeleaf.AttributionView;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/uk/gov/register/presentation/view/RegisterDetailView.java
+++ b/src/main/java/uk/gov/register/presentation/view/RegisterDetailView.java
@@ -1,4 +1,4 @@
-package uk.gov.register.thymeleaf;
+package uk.gov.register.presentation.view;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import uk.gov.organisation.client.GovukOrganisation;

--- a/src/main/java/uk/gov/register/presentation/view/RegisterProofView.java
+++ b/src/main/java/uk/gov/register/presentation/view/RegisterProofView.java
@@ -1,4 +1,4 @@
-package uk.gov.register.thymeleaf;
+package uk.gov.register.presentation.view;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import io.dropwizard.views.View;

--- a/src/main/java/uk/gov/register/presentation/view/SingleEntryView.java
+++ b/src/main/java/uk/gov/register/presentation/view/SingleEntryView.java
@@ -5,7 +5,6 @@ import uk.gov.organisation.client.GovukOrganisation;
 import uk.gov.register.presentation.EntryView;
 import uk.gov.register.presentation.config.PublicBody;
 import uk.gov.register.presentation.resource.RequestContext;
-import uk.gov.register.thymeleaf.AttributionView;
 
 import java.util.Optional;
 

--- a/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
+++ b/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
@@ -11,9 +11,6 @@ import uk.gov.register.presentation.config.PublicBody;
 import uk.gov.register.presentation.config.RegisterDomainConfiguration;
 import uk.gov.register.presentation.resource.Pagination;
 import uk.gov.register.presentation.resource.RequestContext;
-import uk.gov.register.thymeleaf.BadRequestExceptionView;
-import uk.gov.register.thymeleaf.HomePageView;
-import uk.gov.register.thymeleaf.RegisterDetailView;
 import uk.gov.register.thymeleaf.ThymeleafView;
 
 import javax.inject.Inject;

--- a/src/test/java/uk/gov/register/presentation/view/HomePageViewTest.java
+++ b/src/test/java/uk/gov/register/presentation/view/HomePageViewTest.java
@@ -1,4 +1,4 @@
-package uk.gov.register.thymeleaf;
+package uk.gov.register.presentation.view;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
There are view classes in `thymeleaf` package. moving these classes to `view` package so that thymeleaf package only keeps classes which are required to integrate thymeleaf in dropwizard.
