### PR TITLE
Externalize configuration (registers, fields and public bodies)

### DIFF
--- a/src/main/java/uk/gov/register/presentation/app/PresentationApplication.java
+++ b/src/main/java/uk/gov/register/presentation/app/PresentationApplication.java
@@ -43,6 +43,7 @@ import javax.servlet.DispatcherType;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.MediaType;
 import java.util.EnumSet;
+import java.util.Optional;
 
 public class PresentationApplication extends Application<PresentationConfiguration> {
 
@@ -100,9 +101,11 @@ public class PresentationApplication extends Application<PresentationConfigurati
             protected void configure() {
                 bind(queryDAO).to(RecentEntryIndexQueryDAO.class);
                 bind(signedTreeHeadQueryDAO).to(SignedTreeHeadQueryDAO.class);
-                bind(FieldsConfiguration.class).to(FieldsConfiguration.class).in(Singleton.class);
-                bind(PublicBodiesConfiguration.class).to(PublicBodiesConfiguration.class).in(Singleton.class);
-                bind(RegistersConfiguration.class).to(RegistersConfiguration.class).in(Singleton.class);
+
+                bind(new FieldsConfiguration(Optional.ofNullable(System.getProperty("fieldsYaml")))).to(FieldsConfiguration.class);
+                bind(new RegistersConfiguration(Optional.ofNullable(System.getProperty("registersYaml")))).to(RegistersConfiguration.class);
+                bind(new PublicBodiesConfiguration(Optional.ofNullable(System.getProperty("publicBodiesYaml")))).to(PublicBodiesConfiguration.class);
+
                 bind(RequestContext.class).to(RequestContext.class);
                 bind(ViewFactory.class).to(ViewFactory.class).in(Singleton.class);
                 bind(EntryConverter.class).to(EntryConverter.class).in(Singleton.class);

--- a/src/main/java/uk/gov/register/presentation/config/FieldsConfiguration.java
+++ b/src/main/java/uk/gov/register/presentation/config/FieldsConfiguration.java
@@ -3,26 +3,18 @@ package uk.gov.register.presentation.config;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.google.common.collect.Lists;
-import io.dropwizard.jackson.Jackson;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public class FieldsConfiguration {
 
     private final List<Field> fields;
 
-    public FieldsConfiguration() throws IOException {
-        InputStream fieldsStream = this.getClass().getClassLoader().getResourceAsStream("config/fields.yaml");
-        ObjectMapper yamlObjectMapper = Jackson.newObjectMapper(new YAMLFactory());
-        List<FieldData> rawFields = yamlObjectMapper.readValue(fieldsStream, new TypeReference<List<FieldData>>() {
-        });
-        fields = Lists.transform(rawFields, m -> m.entry);
+    public FieldsConfiguration(Optional<String> fieldsResourceYamlPath) {
+        fields = new ResourceYamlFileReader().readResource(fieldsResourceYamlPath, "config/fields.yaml", new TypeReference<List<FieldData>>() {
+        }, t -> t.entry);
     }
 
     public Field getField(String fieldName) {
@@ -30,8 +22,10 @@ public class FieldsConfiguration {
     }
 
     @JsonIgnoreProperties({"hash", "last-updated", "serial-number"})
-    private static class FieldData{
+    private static class FieldData {
         @JsonProperty
         Field entry;
     }
 }
+
+

--- a/src/main/java/uk/gov/register/presentation/config/PublicBodiesConfiguration.java
+++ b/src/main/java/uk/gov/register/presentation/config/PublicBodiesConfiguration.java
@@ -3,26 +3,23 @@ package uk.gov.register.presentation.config;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.google.common.collect.Lists;
-import io.dropwizard.jackson.Jackson;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public class PublicBodiesConfiguration {
 
     private final List<PublicBody> publicBodies;
 
-    public PublicBodiesConfiguration() throws IOException {
-        InputStream publicBodiesStream = this.getClass().getClassLoader().getResourceAsStream("config/public-bodies.yaml");
-        ObjectMapper yamlObjectMapper = Jackson.newObjectMapper(new YAMLFactory());
-        List<PublicBodyData> rawPublicBodies = yamlObjectMapper.readValue(publicBodiesStream, new TypeReference<List<PublicBodyData>>() {
-        });
-        publicBodies = Lists.transform(rawPublicBodies, m -> m.entry);
+    public PublicBodiesConfiguration(Optional<String> publicBodiesResourceYamlPath) {
+        publicBodies = new ResourceYamlFileReader().readResource(
+                publicBodiesResourceYamlPath,
+                "config/public-bodies.yaml",
+                new TypeReference<List<PublicBodyData>>() {
+                },
+                publicBodyData -> publicBodyData.entry
+        );
     }
 
     public PublicBody getPublicBody(String publicBodyId) {
@@ -30,7 +27,7 @@ public class PublicBodiesConfiguration {
     }
 
     @JsonIgnoreProperties({"hash", "last-updated"})
-    private static class PublicBodyData{
+    private static class PublicBodyData {
         @JsonProperty
         PublicBody entry;
     }

--- a/src/main/java/uk/gov/register/presentation/config/RegistersConfiguration.java
+++ b/src/main/java/uk/gov/register/presentation/config/RegistersConfiguration.java
@@ -1,27 +1,26 @@
 package uk.gov.register.presentation.config;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import io.dropwizard.jackson.Jackson;
 import uk.gov.register.presentation.RegisterData;
 
 import javax.inject.Inject;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public class RegistersConfiguration {
 
     private final List<RegisterData> registers;
 
     @Inject
-    public RegistersConfiguration() throws IOException {
-        InputStream registersStream = this.getClass().getClassLoader().getResourceAsStream("config/registers.yaml");
-        ObjectMapper yamlObjectMapper = Jackson.newObjectMapper(new YAMLFactory());
-        registers = yamlObjectMapper.readValue(registersStream, new TypeReference<List<RegisterData>>() {
-        });
+    public RegistersConfiguration(Optional<String> registersResourceYamlPath) {
+        registers = new ResourceYamlFileReader().readResource(
+                registersResourceYamlPath,
+                "config/registers.yaml",
+                new TypeReference<List<RegisterData>>() {
+                },
+                registerData -> registerData
+        );
     }
 
     public RegisterData getRegisterData(String registerName) {

--- a/src/main/java/uk/gov/register/presentation/config/ResourceYamlFileReader.java
+++ b/src/main/java/uk/gov/register/presentation/config/ResourceYamlFileReader.java
@@ -1,0 +1,45 @@
+package uk.gov.register.presentation.config;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.dropwizard.jackson.Jackson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+class ResourceYamlFileReader {
+    private final Logger logger = LoggerFactory.getLogger(ResourceYamlFileReader.class);
+    private final ObjectMapper yamlObjectMapper = Jackson.newObjectMapper(new YAMLFactory());
+
+    @FunctionalInterface
+    interface RawDataConverter<R, S> {
+        S convert(R t);
+    }
+
+    public <M, T> List<T> readResource(Optional<String> resourceYamlPath,
+                                              String defaultResourceYamlFilePath,
+                                              TypeReference<List<M>> typeReference,
+                                              RawDataConverter<M, T> rawDataConverter) {
+        try {
+            InputStream fieldsStream = new ResourceYamlFileReader().getStreamFromFile(resourceYamlPath, defaultResourceYamlFilePath);
+            return yamlObjectMapper.<List<M>>readValue(fieldsStream, typeReference).stream().map(rawDataConverter::convert).collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new RuntimeException("Error loading resource configuration file.", e);
+        }
+    }
+
+    private InputStream getStreamFromFile(Optional<String> resourceYamlPath, String defaultResourceYamlFilePath) throws FileNotFoundException {
+        if (resourceYamlPath.isPresent()) {
+            logger.info("Loading external file '" + resourceYamlPath.get() + ".");
+            return new FileInputStream(new File(resourceYamlPath.get()));
+        } else {
+            logger.info("Loading internal file '" + defaultResourceYamlFilePath + "'.");
+            return this.getClass().getClassLoader().getResourceAsStream(defaultResourceYamlFilePath);
+        }
+    }
+}

--- a/src/test/java/uk/gov/register/presentation/EntryConverterTest.java
+++ b/src/test/java/uk/gov/register/presentation/EntryConverterTest.java
@@ -12,6 +12,7 @@ import uk.gov.register.presentation.config.FieldsConfiguration;
 import uk.gov.register.presentation.resource.RequestContext;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
@@ -26,7 +27,7 @@ public class EntryConverterTest {
 
     @Before
     public void setUp() throws Exception {
-        entryConverter = new EntryConverter(new FieldsConfiguration(), () -> "test.register.gov.uk", requestContext);
+        entryConverter = new EntryConverter(new FieldsConfiguration(Optional.empty()), () -> "test.register.gov.uk", requestContext);
     }
 
     @Test

--- a/src/test/java/uk/gov/register/presentation/representations/TurtleWriterTest.java
+++ b/src/test/java/uk/gov/register/presentation/representations/TurtleWriterTest.java
@@ -14,6 +14,7 @@ import uk.gov.register.presentation.resource.RequestContext;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -25,7 +26,7 @@ public class TurtleWriterTest {
 
     @Before
     public void setUp() throws Exception {
-        RequestContext requestContext = new RequestContext(new RegistersConfiguration(), () -> "test.register.gov.uk") {
+        RequestContext requestContext = new RequestContext(new RegistersConfiguration(Optional.empty()), () -> "test.register.gov.uk") {
             @Override
             public String requestUrl() {
                 return "http://widget.openregister.org/widget/123";

--- a/src/test/java/uk/gov/register/presentation/resource/HistoryResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/HistoryResourceTest.java
@@ -18,6 +18,7 @@ import uk.gov.register.presentation.view.ViewFactory;
 import javax.ws.rs.NotFoundException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -37,7 +38,7 @@ public class HistoryResourceTest {
 
     @Before
     public void setUp() throws Exception {
-        resource = new HistoryResource(new RequestContext(new RegistersConfiguration(), () -> "") {
+        resource = new HistoryResource(new RequestContext(new RegistersConfiguration(Optional.empty()), () -> "") {
             @Override
             public String getRegisterPrimaryKey() {
                 return "school";

--- a/src/test/java/uk/gov/register/presentation/resource/RequestContextTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/RequestContextTest.java
@@ -8,6 +8,8 @@ import uk.gov.register.presentation.config.RegistersConfiguration;
 
 import javax.servlet.http.HttpServletRequest;
 
+import java.util.Optional;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.when;
@@ -19,7 +21,7 @@ public class RequestContextTest {
 
     @Test
     public void takesRegisterNameFromHttpHost() throws Exception {
-        RequestContext requestContext = new RequestContext(new RegistersConfiguration(), () -> "");
+        RequestContext requestContext = new RequestContext(new RegistersConfiguration(Optional.empty()), () -> "");
         requestContext.httpServletRequest = httpServletRequest;
         when(httpServletRequest.getHeader("Host")).thenReturn("school.beta.openregister.org");
 
@@ -30,7 +32,7 @@ public class RequestContextTest {
 
     @Test
     public void behavesGracefullyWhenGivenHostWithNoDots() throws Exception {
-        RequestContext requestContext = new RequestContext(new RegistersConfiguration(), () -> "");
+        RequestContext requestContext = new RequestContext(new RegistersConfiguration(Optional.empty()), () -> "");
         requestContext.httpServletRequest = httpServletRequest;
         when(httpServletRequest.getHeader("Host")).thenReturn("school");
 

--- a/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
@@ -43,7 +43,7 @@ public class SearchResourceTest {
 
     @Before
     public void setUp() throws Exception {
-        requestContext = new RequestContext(new RegistersConfiguration(), () -> ""){
+        requestContext = new RequestContext(new RegistersConfiguration(Optional.empty()), () -> ""){
             @Override
             public HttpServletResponse getHttpServletResponse() {
                 return servletResponse;


### PR DESCRIPTION
Currently we have register meta-data specific yaml configuration files in the code. Every time there is a change in meta data we have to change the code, commit it and redeploy the new version. 

To avoid this commit and redeploy process this PR adds the capability to externalize these configuration files so that only restarting the application is required which will pick new configuration files from the external location.

There are three system properties introduced which are needed at application start to specify external location of these configuration files. `-DfieldsYaml`, `-DregistersYaml` and `-DpublicBodiesYaml` are the system properties.

Change the `start-service.sh` script in deploy directory and then redeploy the application to start consuming files from external location. Refer mint application, It uses the same process to consume externalized config.
