### PR TITLE
Disable the download resources by default

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,3 +19,5 @@ database:
 
   properties:
     charSet: UTF-8
+
+enableDownloadResource: true

--- a/src/main/java/uk/gov/register/presentation/config/PresentationConfiguration.java
+++ b/src/main/java/uk/gov/register/presentation/config/PresentationConfiguration.java
@@ -10,7 +10,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.net.URI;
 
-public class PresentationConfiguration extends Configuration implements GovukClientConfiguration, RegisterDomainConfiguration {
+public class PresentationConfiguration extends Configuration implements GovukClientConfiguration, RegisterDomainConfiguration, ResourceConfiguration {
     @Valid
     @NotNull
     @JsonProperty
@@ -25,6 +25,10 @@ public class PresentationConfiguration extends Configuration implements GovukCli
     @NotNull
     @JsonProperty
     private String registerDomain = "openregister.org";
+
+    @Valid
+    @JsonProperty
+    private boolean enableDownloadResource = false;
 
     @Override
     public String getRegisterDomain() {
@@ -42,5 +46,10 @@ public class PresentationConfiguration extends Configuration implements GovukCli
     @Override
     public URI getGovukEndpoint() {
         return URI.create("https://www.gov.uk");
+    }
+
+    @Override
+    public boolean getEnableDownloadResource() {
+        return enableDownloadResource;
     }
 }

--- a/src/main/java/uk/gov/register/presentation/config/ResourceConfiguration.java
+++ b/src/main/java/uk/gov/register/presentation/config/ResourceConfiguration.java
@@ -1,0 +1,8 @@
+package uk.gov.register.presentation.config;
+
+import org.jvnet.hk2.annotations.Contract;
+
+@Contract
+public interface ResourceConfiguration {
+    boolean getEnableDownloadResource();
+}

--- a/src/main/java/uk/gov/register/presentation/resource/DataResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/DataResource.java
@@ -43,7 +43,8 @@ public class DataResource {
 
     @GET
     @Path("/download-register")
-    @Produces(MediaType.APPLICATION_OCTET_STREAM)
+    @Produces({MediaType.APPLICATION_OCTET_STREAM, ExtraMediaType.TEXT_HTML})
+    @DownloadNotAvailable
     public Response downloadRegister() {
         List<DbEntry> entries = queryDAO.getAllEntriesNoPagination();
         SignedTreeHead sth = signedTreeHeadQueryDAO.get();
@@ -59,12 +60,14 @@ public class DataResource {
                 .ok(new ArchiveCreator().create(registerDetail, entries, sth))
                 .header("Content-Disposition", String.format("attachment; filename=%s-%d.zip", requestContext.getRegisterPrimaryKey(), System.currentTimeMillis()))
                 .header("Content-Transfer-Encoding", "binary")
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM)
                 .build();
     }
 
     @GET
     @Path("/download")
     @Produces(ExtraMediaType.TEXT_HTML)
+    @DownloadNotAvailable
     public View download() {
         return viewFactory.thymeleafView("download.html");
     }
@@ -72,6 +75,7 @@ public class DataResource {
     @GET
     @Path("/download.torrent")
     @Produces(ExtraMediaType.TEXT_HTML)
+    @DownloadNotAvailable
     public Response downloadTorrent() {
         return Response
                 .status(Response.Status.NOT_IMPLEMENTED)

--- a/src/main/java/uk/gov/register/presentation/resource/DownloadNotAvailable.java
+++ b/src/main/java/uk/gov/register/presentation/resource/DownloadNotAvailable.java
@@ -1,0 +1,13 @@
+package uk.gov.register.presentation.resource;
+
+import javax.ws.rs.NameBinding;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@NameBinding
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DownloadNotAvailable {
+}

--- a/src/main/java/uk/gov/register/presentation/resource/ResourceAvailabilityFilter.java
+++ b/src/main/java/uk/gov/register/presentation/resource/ResourceAvailabilityFilter.java
@@ -1,0 +1,37 @@
+package uk.gov.register.presentation.resource;
+
+import uk.gov.register.presentation.config.ResourceConfiguration;
+import uk.gov.register.presentation.view.ViewFactory;
+
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+
+@Provider
+@DownloadNotAvailable
+public class ResourceAvailabilityFilter implements ContainerRequestFilter {
+
+    private final ResourceConfiguration resourceConfiguration;
+    private final ViewFactory viewFactory;
+
+    @Inject
+    public ResourceAvailabilityFilter(ResourceConfiguration resourceConfiguration, ViewFactory viewFactory) {
+        this.resourceConfiguration = resourceConfiguration;
+        this.viewFactory = viewFactory;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        if (!resourceConfiguration.getEnableDownloadResource()) {
+            Response response = Response
+                    .status(Response.Status.NOT_IMPLEMENTED)
+                    .entity(viewFactory.thymeleafView("not-implemented.html"))
+                    .build();
+
+            requestContext.abortWith(response);
+        }
+    }
+}

--- a/src/test/java/uk/gov/register/presentation/resource/ResourceAvailabilityFilterTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/ResourceAvailabilityFilterTest.java
@@ -1,0 +1,53 @@
+package uk.gov.register.presentation.resource;
+
+import io.dropwizard.testing.junit.ResourceTestRule;
+import org.junit.Rule;
+import org.junit.Test;
+import uk.gov.register.presentation.config.ResourceConfiguration;
+import uk.gov.register.presentation.view.ViewFactory;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ResourceAvailabilityFilterTest {
+
+    @Rule
+    public ResourceTestRule resourceNotAvailableRule = ResourceTestRule.builder().addResource(new DummyResource()).addProvider(getResourceAvailabilityFilter(false)).build();
+    @Rule
+    public ResourceTestRule resourceAvailableRule = ResourceTestRule.builder().addResource(new DummyResource()).addProvider(getResourceAvailabilityFilter(true)).build();
+
+    @Test
+    public void shouldReturn501WhenEnableDownloadSetToFalse() {
+        Response response = resourceNotAvailableRule.client().target("/test").request().get();
+        assertThat(response.getStatus(), equalTo(501));
+    }
+
+    @Test
+    public void shouldReturn200WhenEnableDownloadSetToTrue() {
+        Response response = resourceAvailableRule.client().target("/test").request().get();
+        assertThat(response.getStatus(), equalTo(200));
+    }
+
+    @Path("/")
+    public class DummyResource {
+        @GET
+        @Path("test")
+        @DownloadNotAvailable
+        public String getPrincipal() {
+            return "success";
+        }
+    }
+
+    private ResourceAvailabilityFilter getResourceAvailabilityFilter(boolean available) {
+        ViewFactory viewFactory = mock(ViewFactory.class);
+        ResourceConfiguration resourceConfiguration = mock(ResourceConfiguration.class);
+        when(resourceConfiguration.getEnableDownloadResource()).thenReturn(available);
+        return new ResourceAvailabilityFilter(resourceConfiguration, viewFactory);
+    }
+}

--- a/src/test/resources/test-app-config.yaml
+++ b/src/test/resources/test-app-config.yaml
@@ -23,3 +23,5 @@ database:
 
   properties:
     charSet: UTF-8
+
+enableDownloadResource: true


### PR DESCRIPTION
Introduce a request filter that produces a NotImplemented reponse for resources that have the annotation and based on the enableDownloadResource property in the register config.yaml
