### PR TITLE
Add scope attribute to all `<th>` tags

### DIFF
--- a/src/main/resources/templates/entries.html
+++ b/src/main/resources/templates/entries.html
@@ -14,10 +14,10 @@
     <table th:if="${#lists.isEmpty(entries) == false}">
         <thead>
         <tr>
-            <th>Entry</th>
-            <th><a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(registerId, registerDomain)}" th:text="${registerId}"></a></th>
+            <th scope="col">Entry</th>
+            <th scope="col"><a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(registerId, registerDomain)}" th:text="${registerId}"></a></th>
             <th:block th:each="fieldName : ${register.nonPrimaryFields}">
-                <th><a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(fieldName, registerDomain)}" th:text="${fieldName}"></a></th>
+                <th scope="col"><a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(fieldName, registerDomain)}" th:text="${fieldName}"></a></th>
             </th:block>
         </tr>
         </thead>

--- a/src/main/resources/templates/fragments/entry-table.html
+++ b/src/main/resources/templates/fragments/entry-table.html
@@ -10,8 +10,8 @@
         </colgroup>
         <thead>
             <tr>
-                <th>Field</th>
-                <th>Value</th>
+                <th scope="col">Field</th>
+                <th scope="col">Value</th>
             </tr>
         </thead>
         <tbody>

--- a/src/main/resources/templates/history.html
+++ b/src/main/resources/templates/history.html
@@ -10,8 +10,8 @@
     <table>
         <thead>
             <tr>
-                <th>Entry</th>
-                <th>Hash</th>
+                <th scope="col">Entry</th>
+                <th scope="col">Hash</th>
             </tr>
         </thead>
         <tbody>

--- a/src/main/resources/templates/records.html
+++ b/src/main/resources/templates/records.html
@@ -13,9 +13,9 @@
     <table th:if="${#lists.isEmpty(entries) == false}">
         <thead>
             <tr>
-                <th><a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(registerId, registerDomain)}" th:text="${registerId}"></a></th>
+                <th scope="col"><a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(registerId, registerDomain)}" th:text="${registerId}"></a></th>
                 <th:block th:each="fieldName : ${register.nonPrimaryFields}">
-                    <th><a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(fieldName, registerDomain)}" th:text="${fieldName}"></a></th>
+                    <th scope="col"><a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(fieldName, registerDomain)}" th:text="${fieldName}"></a></th>
                 </th:block>
             </tr>
         </thead>


### PR DESCRIPTION
In each case, the `<th>` tag is a column header -- rather than a
colgroup, row, or rowgroup header.

Web content accessibility guidelines ref: https://www.w3.org/TR/WCAG20-TECHS/H63.html

HTML5 ref: https://www.w3.org/TR/2012/WD-html5-20121025/the-th-element.html#attr-th-scope
