### PR TITLE
Using total_entries table last_updated column to render last_updated time of register

### DIFF
--- a/src/main/java/uk/gov/register/presentation/RegisterDetail.java
+++ b/src/main/java/uk/gov/register/presentation/RegisterDetail.java
@@ -3,8 +3,11 @@ package uk.gov.register.presentation;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 
 public class RegisterDetail {
+    private static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ISO_INSTANT;
+
     private final String domain;
     private final int totalRecords;
     private final int totalEntries;
@@ -35,7 +38,7 @@ public class RegisterDetail {
     @SuppressWarnings("unused, used from template")
     @JsonProperty("last-updated")
     public String getLastUpdatedTime() {
-        return lastUpdated.toString();
+        return dateTimeFormatter.format(lastUpdated);
     }
 
     @JsonProperty("record")

--- a/src/main/java/uk/gov/register/presentation/RegisterDetail.java
+++ b/src/main/java/uk/gov/register/presentation/RegisterDetail.java
@@ -3,14 +3,13 @@ package uk.gov.register.presentation;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.Instant;
-import java.util.Optional;
 
 public class RegisterDetail {
     private final String domain;
     private final int totalRecords;
     private final int totalEntries;
     private final int totalItems;
-    private final Optional<Instant> lastUpdated;
+    private final Instant lastUpdated;
     private final EntryView entryView;
 
     public RegisterDetail(
@@ -18,7 +17,7 @@ public class RegisterDetail {
             int totalRecords,
             int totalEntries,
             int totalItems,
-            Optional<Instant> lastUpdated,
+            Instant lastUpdated,
             EntryView entryView) {
         this.domain = domain;
         this.totalRecords = totalRecords;
@@ -36,7 +35,7 @@ public class RegisterDetail {
     @SuppressWarnings("unused, used from template")
     @JsonProperty("last-updated")
     public String getLastUpdatedTime() {
-        return lastUpdated.map(Instant::toString).orElse("");
+        return lastUpdated.toString();
     }
 
     @JsonProperty("record")

--- a/src/main/java/uk/gov/register/presentation/view/HomePageView.java
+++ b/src/main/java/uk/gov/register/presentation/view/HomePageView.java
@@ -16,7 +16,7 @@ public class HomePageView extends AttributionView {
 
     private final MarkdownProcessor markdownProcessor = new MarkdownProcessor();
 
-    private final Optional<Instant> lastUpdated;
+    private final Instant lastUpdated;
     private final int totalRecords;
     private final int totalEntries;
     private final String registerDomain;
@@ -27,7 +27,7 @@ public class HomePageView extends AttributionView {
             RequestContext requestContext,
             int totalRecords,
             int totalEntries,
-            Optional<Instant> lastUpdated,
+            Instant lastUpdated,
             String registerDomain
     ) {
         super(requestContext, custodian, custodianBranding, "home.html");
@@ -54,7 +54,7 @@ public class HomePageView extends AttributionView {
 
     @SuppressWarnings("unused, used from template")
     public String getLastUpdatedTime() {
-        return lastUpdated.map(DATE_TIME_FORMATTER::format).orElse("");
+        return DATE_TIME_FORMATTER.format(lastUpdated);
     }
 
     @SuppressWarnings("unused, used from template")

--- a/src/main/java/uk/gov/register/presentation/view/RegisterDetailView.java
+++ b/src/main/java/uk/gov/register/presentation/view/RegisterDetailView.java
@@ -16,7 +16,7 @@ public class RegisterDetailView extends AttributionView {
     private final int totalRecords;
     private final int totalEntries;
     private final int totalItems;
-    private final Optional<Instant> lastUpdated;
+    private final Instant lastUpdated;
 
     public RegisterDetailView(
             PublicBody custodian,
@@ -26,7 +26,7 @@ public class RegisterDetailView extends AttributionView {
             int totalRecords,
             int totalEntries,
             int totalItems,
-            Optional<Instant> lastUpdated) {
+            Instant lastUpdated) {
         super(requestContext, custodian, custodianBranding, "");
         this.entryConverter = entryConverter;
         this.totalRecords = totalRecords;

--- a/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
+++ b/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
@@ -77,11 +77,11 @@ public class ViewFactory {
         return new BadRequestExceptionView(requestContext, e);
     }
 
-    public HomePageView homePageView(int totalRecords, int totalEntries, Optional<Instant> lastUpdated) {
+    public HomePageView homePageView(int totalRecords, int totalEntries, Instant lastUpdated) {
         return new HomePageView(getCustodian(), getBranding(), requestContext, totalRecords, totalEntries, lastUpdated, registerDomain);
     }
 
-    public RegisterDetailView registerDetailView(int totalRecords, int totalEntries, int totalItems, Optional<Instant> lastUpdated) {
+    public RegisterDetailView registerDetailView(int totalRecords, int totalEntries, int totalItems, Instant lastUpdated) {
         return new RegisterDetailView(getCustodian(), getBranding(), requestContext, entryConverter, totalRecords, totalEntries, totalItems, lastUpdated);
     }
 

--- a/src/test/java/uk/gov/register/presentation/RegisterDetailTest.java
+++ b/src/test/java/uk/gov/register/presentation/RegisterDetailTest.java
@@ -3,21 +3,14 @@ package uk.gov.register.presentation;
 import org.junit.Test;
 
 import java.time.Instant;
-import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 public class RegisterDetailTest {
     @Test
-    public void getLastUpdatedTime_returnsTheEmptyStringIfNoTimeStampExists() {
-        RegisterDetail registerDetail = new RegisterDetail("", 0, 0, 0, Optional.<Instant>empty(), null);
-        assertThat(registerDetail.getLastUpdatedTime(), equalTo(""));
-    }
-
-    @Test
     public void getLastUpdatedTime_returnsTheTimestampIfExists() {
-        RegisterDetail registerDetail = new RegisterDetail("", 0, 0, 0, Optional.of(Instant.ofEpochMilli(1411111111)), null);
+        RegisterDetail registerDetail = new RegisterDetail("", 0, 0, 0, Instant.ofEpochMilli(1411111111), null);
         assertThat(registerDetail.getLastUpdatedTime(), equalTo("1970-01-17T07:58:31.111Z"));
     }
 }

--- a/src/test/java/uk/gov/register/presentation/functional/RegisterResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/RegisterResourceFunctionalTest.java
@@ -11,15 +11,9 @@ import org.junit.Test;
 import uk.gov.register.presentation.functional.testSupport.DBSupport;
 
 import javax.ws.rs.core.Response;
-
 import java.io.IOException;
 import java.io.InputStream;
-import java.time.Instant;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.SortedMap;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsString;
@@ -37,7 +31,7 @@ public class RegisterResourceFunctionalTest extends FunctionalTestBase {
 
         cleanDatabaseRule.before();
 
-        Long addressRegisterLastUpdatedTime = populateAddressRegisterEntries().get();
+        populateAddressRegisterEntries();
         Response addressRegisterResourceResponse = getRequest("address", "/register.json");
         assertThat(addressRegisterResourceResponse.getStatus(), equalTo(200));
 
@@ -45,15 +39,14 @@ public class RegisterResourceFunctionalTest extends FunctionalTestBase {
         assertThat(addressRegisterResourceJsonResponse, containsString("\"total-entries\":5"));
         assertThat(addressRegisterResourceJsonResponse, containsString("\"total-records\":3"));
         assertThat(addressRegisterResourceJsonResponse, containsString("\"total-items\":5"));
-        assertThat(addressRegisterResourceJsonResponse, containsString(String.format("\"last-updated\":\"%s\"",
-                Instant.ofEpochMilli(addressRegisterLastUpdatedTime).toString())));
+        assertThat(addressRegisterResourceJsonResponse, containsString("\"last-updated\":"));
 
         String registerRegisterEntryJsonResponse = registerRegisterEntryResponse.readEntity(String.class);
         assertThat(addressRegisterResourceJsonResponse, containsString(registerRegisterEntryJsonResponse));
     }
 
-    public Optional<Long> populateAddressRegisterEntries() {
-        return DBSupport.publishMessages(ImmutableList.of(
+    public void populateAddressRegisterEntries() {
+        DBSupport.publishMessages(ImmutableList.of(
                 "{\"hash\":\"hash1\",\"entry\":{\"name\":\"ellis\",\"address\":\"12345\"}}",
                 "{\"hash\":\"hash2\",\"entry\":{\"name\":\"presley\",\"address\":\"6789\"}}",
                 "{\"hash\":\"hash3\",\"entry\":{\"name\":\"ellis\",\"address\":\"145678\"}}",

--- a/src/test/java/uk/gov/register/presentation/functional/RegisterResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/RegisterResourceFunctionalTest.java
@@ -13,10 +13,14 @@ import uk.gov.register.presentation.functional.testSupport.DBSupport;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -35,14 +39,15 @@ public class RegisterResourceFunctionalTest extends FunctionalTestBase {
         Response addressRegisterResourceResponse = getRequest("address", "/register.json");
         assertThat(addressRegisterResourceResponse.getStatus(), equalTo(200));
 
-        String addressRegisterResourceJsonResponse = addressRegisterResourceResponse.readEntity(String.class);
-        assertThat(addressRegisterResourceJsonResponse, containsString("\"total-entries\":5"));
-        assertThat(addressRegisterResourceJsonResponse, containsString("\"total-records\":3"));
-        assertThat(addressRegisterResourceJsonResponse, containsString("\"total-items\":5"));
-        assertThat(addressRegisterResourceJsonResponse, containsString("\"last-updated\":"));
+        JsonNode registerJson = addressRegisterResourceResponse.readEntity(JsonNode.class);
 
-        String registerRegisterEntryJsonResponse = registerRegisterEntryResponse.readEntity(String.class);
-        assertThat(addressRegisterResourceJsonResponse, containsString(registerRegisterEntryJsonResponse));
+        assertThat(registerJson.get("total-entries").intValue(), equalTo(5));
+        assertThat(registerJson.get("total-records").intValue(), equalTo(3));
+        assertThat(registerJson.get("total-items").intValue(), equalTo(5));
+        verifyStringIsAnISODate(registerJson.get("last-updated").textValue());
+
+        JsonNode registerRecordJson = registerRegisterEntryResponse.readEntity(JsonNode.class);
+        assertThat(registerJson.get("record"), equalTo(registerRecordJson));
     }
 
     public void populateAddressRegisterEntries() {
@@ -67,8 +72,14 @@ public class RegisterResourceFunctionalTest extends FunctionalTestBase {
                     rootNode.set("hash", m.get("hash"));
                     rootNode.set("entry", m.get("entry"));
                     return rootNode.toString();
-                }, (a,b) -> a, TreeMap::new));
+                }, (a, b) -> a, TreeMap::new));
 
         DBSupport.publishMessages("register", registerEntries);
+    }
+
+    private void verifyStringIsAnISODate(String lastUpdated) {
+        DateTimeFormatter isoFormatter = DateTimeFormatter.ISO_INSTANT;
+        TemporalAccessor parsedDate = isoFormatter.parse(lastUpdated);
+        assertThat(isoFormatter.format(parsedDate), equalTo(lastUpdated));
     }
 }

--- a/src/test/java/uk/gov/register/presentation/functional/testSupport/DBSupport.java
+++ b/src/test/java/uk/gov/register/presentation/functional/testSupport/DBSupport.java
@@ -10,9 +10,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.List;
-import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
@@ -21,6 +23,7 @@ import java.util.stream.Stream;
 public class DBSupport {
 
     private static final DataSource pooledDataSource = new DataSource();
+
     static {
         pooledDataSource.setDriverClassName("org.postgresql.Driver");
         pooledDataSource.setUrl(FunctionalTestBase.DATABASE_URL);
@@ -40,18 +43,18 @@ public class DBSupport {
         }
     }
 
-    public static Optional<Long> publishMessages(List<String> messages) {
-        return publishMessages("address", messages);
+    public static void publishMessages(List<String> messages) {
+        publishMessages("address", messages);
     }
 
-    public static Optional<Long> publishMessages(String registerName, List<String> messages) {
+    public static void publishMessages(String registerName, List<String> messages) {
         SortedMap<Integer, String> messagesWithSerialNumbers = messages.stream().collect(Collectors.toMap(m -> messages.indexOf(m) + 1, m -> m, (a, b) -> a, TreeMap::new));
-        return publishMessages(registerName, messagesWithSerialNumbers);
+        publishMessages(registerName, messagesWithSerialNumbers);
     }
 
-    public static Optional<Long> publishMessages(String registerName, SortedMap<Integer, String> messages) {
+    public static void publishMessages(String registerName, SortedMap<Integer, String> messages) {
         try (Connection connection = pooledDataSource.getConnection()) {
-            return publishMessages(connection, registerName, messages);
+            publishMessages(connection, registerName, messages);
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
@@ -94,24 +97,19 @@ public class DBSupport {
         publishMessages(connection, registerName, messagesWithSerialNumbers);
     }
 
-    private static Optional<Long> publishMessages(Connection connection, String registerName, SortedMap<Integer, String> messages) throws SQLException {
-        Optional<Long> lastUpdatedTime = Optional.empty();
+    private static void publishMessages(Connection connection, String registerName, SortedMap<Integer, String> messages) throws SQLException {
         for (SortedMap.Entry<Integer, String> entry : messages.entrySet()) {
             int serialNumber = entry.getKey();
             String message = entry.getValue();
             try (PreparedStatement insertPreparedStatement = connection.prepareStatement("Insert into ordered_entry_index(serial_number,entry,leaf_input) values(?,?, ?)")) {
-                Long updateTime;
                 insertPreparedStatement.setObject(1, serialNumber);
                 insertPreparedStatement.setObject(2, jsonbObject(message));
-                insertPreparedStatement.setString(3, CTLeafInputGenerator.createLeafInputFrom(itemData(message), updateTime = System.currentTimeMillis()));
+                insertPreparedStatement.setString(3, CTLeafInputGenerator.createLeafInputFrom(itemData(message), System.currentTimeMillis()));
                 insertPreparedStatement.execute();
-                lastUpdatedTime = Optional.ofNullable(updateTime);
             }
 
             updateOtherTables(connection, registerName, serialNumber, message);
         }
-
-        return lastUpdatedTime;
     }
 
     private static void updateOtherTables(Connection connection, String registerName, int serialNumber, String message) throws SQLException {

--- a/src/test/java/uk/gov/register/presentation/view/HomePageViewTest.java
+++ b/src/test/java/uk/gov/register/presentation/view/HomePageViewTest.java
@@ -11,7 +11,6 @@ import uk.gov.register.presentation.resource.RequestContext;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.Optional;
 
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
@@ -39,7 +38,7 @@ public class HomePageViewTest {
     public void getLastUpdatedTime_formatsTheLocalDateTimeToUKDateTimeFormat() {
         Instant instant = LocalDateTime.of(2015, 9, 11, 13, 17, 59, 543).toInstant(ZoneOffset.UTC);
 
-        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, Optional.of(instant), "openregister.org");
+        HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, instant, "openregister.org");
 
         assertThat(homePageView.getLastUpdatedTime(), equalTo("11 Sep 2015"));
     }


### PR DESCRIPTION
We will not use x-json sever  (refer: openregister/mint#64) now which allows us to remove leaf_input column completely from `ordered_entry_index` table. `last_update` column in total entries contains the time when the last entry was added in to the register which can be used now for this purpose.
