### PR TITLE
Resolved BUG: pagination header always says 0 records when search by key/value

### DIFF
--- a/src/main/java/uk/gov/register/presentation/dao/RecentEntryIndexQueryDAO.java
+++ b/src/main/java/uk/gov/register/presentation/dao/RecentEntryIndexQueryDAO.java
@@ -41,6 +41,10 @@ public abstract class RecentEntryIndexQueryDAO {
     @SingleValueResult(DbEntry.class)
     public abstract Optional<DbEntry> findEntryBySerialNumber(@Bind("serial") long serial);
 
+    @SqlQuery("SELECT serial_number,entry from ordered_entry_index where serial_number = (select serial_number from current_keys where key=:key)")
+    @SingleValueResult(DbEntry.class)
+    public abstract Optional<DbEntry> findRecordByPrimaryKey(@Bind("key") String primaryKey);
+
     @SqlQuery("SELECT serial_number,entry FROM (" +
             "SELECT idx.serial_number, idx.entry FROM ordered_entry_index idx, current_keys ck " +
             "WHERE  entry @> :content " +

--- a/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
@@ -35,14 +35,12 @@ public class SearchResource {
     @Path("/{key}/{value}")
     @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
     public ThymeleafView find(@PathParam("key") String key, @PathParam("value") String value) throws Exception {
-
-        List<DbEntry> records = queryDAO.findLatestEntriesOfRecordsByKeyValue(key, value);
-
         if (key.equals(requestContext.getRegisterPrimaryKey())) {
-            return entryResponse(records.stream().findFirst(), viewFactory::getLatestEntryView);
+            return entryResponse(queryDAO.findRecordByPrimaryKey(value), viewFactory::getLatestEntryView);
         }
 
-        Pagination pagination = new Pagination(Optional.empty(), Optional.empty(), 0);
+        List<DbEntry> records = queryDAO.findLatestEntriesOfRecordsByKeyValue(key, value);
+        Pagination pagination = new Pagination(Optional.empty(), Optional.empty(), records.size());
         return viewFactory.getRecordsView(records, pagination);
     }
 

--- a/src/test/java/uk/gov/register/presentation/functional/FindEntityTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/FindEntityTest.java
@@ -2,6 +2,8 @@ package uk.gov.register.presentation.functional;
 
 import com.google.common.collect.ImmutableList;
 import org.json.JSONException;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -42,4 +44,14 @@ public class FindEntityTest extends FunctionalTestBase {
                 "\"entry\":{\"name\":\"presley\",\"address\":\"6789\"}}"
                 , response.readEntity(String.class), false);
     }
+
+    @Test
+    public void find_returnsTheCorrectTotalRecordsInPaginationHeader(){
+        Response response = getRequest("/name/ellis");
+
+        Document doc = Jsoup.parse(response.readEntity(String.class));
+
+        assertThat(doc.body().getElementById("main").getElementsByAttributeValue("class", "column-two-thirds").first().text(), equalTo("2 records"));
+    }
+
 }


### PR DESCRIPTION
When search by key/value the pagination object had hardcoded value `0` as total entries so `0 records` was rendered always.

Now returning the size of fetched records in pagination object so that the correct value is rendered by html template.
