### PR TITLE
Tightened up CORS to disallow credentials, and non-GET/HEAD requests.

### DIFF
--- a/src/main/java/uk/gov/register/presentation/app/PresentationApplication.java
+++ b/src/main/java/uk/gov/register/presentation/app/PresentationApplication.java
@@ -140,6 +140,8 @@ public class PresentationApplication extends Application<PresentationConfigurati
                 .addFilter(CrossOriginFilter.class, "/*", EnumSet.allOf(DispatcherType.class));
         filterHolder.setInitParameter(CrossOriginFilter.ALLOWED_ORIGINS_PARAM, "*");
         filterHolder.setInitParameter(CrossOriginFilter.ALLOWED_HEADERS_PARAM, "X-Requested-With,Content-Type,Accept,Origin");
-        filterHolder.setInitParameter(CrossOriginFilter.ALLOWED_METHODS_PARAM, "OPTIONS,GET,PUT,POST,DELETE,HEAD");
+        filterHolder.setInitParameter(CrossOriginFilter.ALLOWED_METHODS_PARAM, "GET,HEAD");
+
+        filterHolder.setInitParameter(CrossOriginFilter.ALLOW_CREDENTIALS_PARAM, "false");
     }
 }

--- a/src/test/java/uk/gov/register/presentation/functional/ApplicationTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/ApplicationTest.java
@@ -10,8 +10,7 @@ import org.junit.Test;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
 
@@ -30,9 +29,9 @@ public class ApplicationTest extends FunctionalTestBase {
         MultivaluedMap<String, Object> headers = response.getHeaders();
 
         assertThat(headers.get(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN), equalTo(ImmutableList.of(origin)));
-        assertThat(headers.get(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS), equalTo(ImmutableList.of("true")));
+        assertThat(headers.get(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS), is(nullValue()));
         assertNotNull(headers.get(HttpHeaders.ACCESS_CONTROL_MAX_AGE));
-        assertThat(headers.get(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS), equalTo(ImmutableList.of("OPTIONS,GET,PUT,POST,DELETE,HEAD")));
+        assertThat(headers.get(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS), equalTo(ImmutableList.of("GET,HEAD")));
         assertThat(headers.get(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS), equalTo(ImmutableList.of("X-Requested-With,Content-Type,Accept,Origin")));
     }
 


### PR DESCRIPTION
``` bash
$ curl -si -H "Origin: http://example.com"  \
-H "Access-Control-Request-Method: POST" \
-H "Access-Control-Request-Headers: X-Requested-With" \
-X OPTIONS \
http://public-body.openregister.dev:8080/public-body/employment-tribunal

HTTP/1.1 200 OK
Date: Mon, 14 Mar 2016 17:19:06 GMT
Content-Type: text/plain
Allow: HEAD,GET,OPTIONS
X-Content-Type-Options: nosniff
Content-Security-Policy: default-src 'self'
X-XSS-Protection: 1; mode=block
Cache-Control: no-transform
Content-Length: 18
```
