### PR TITLE
Serve same 404 for assets

### DIFF
--- a/src/main/java/uk/gov/register/presentation/AssetsBundleCustomErrorHandler.java
+++ b/src/main/java/uk/gov/register/presentation/AssetsBundleCustomErrorHandler.java
@@ -44,6 +44,10 @@ public class AssetsBundleCustomErrorHandler extends ErrorHandler {
 
     @Override
     public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
+        if (response.getStatus() != HttpServletResponse.SC_NOT_FOUND) {
+            return;
+        }
+
         baseRequest.setHandled(true);
 
         ServletContext sc = baseRequest.getContext();
@@ -51,7 +55,7 @@ public class AssetsBundleCustomErrorHandler extends ErrorHandler {
         RegistersConfiguration rc = sl.getService(RegistersConfiguration.class);
         String registerId = RegisterNameExtractor.extractRegisterName(request.getHeader("Host"));
         RegisterData rd = rc.getRegisterData(registerId);
-        String registerName = registerId.replace('-',' ');
+        String registerName = registerId.replace('-', ' ');
 
         WebContext wc = new WebContext(request, response, sc,
                 request.getLocale());

--- a/src/main/java/uk/gov/register/presentation/AssetsBundleCustomErrorHandler.java
+++ b/src/main/java/uk/gov/register/presentation/AssetsBundleCustomErrorHandler.java
@@ -1,0 +1,57 @@
+package uk.gov.register.presentation;
+
+import io.dropwizard.setup.Environment;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.ErrorHandler;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.WebContext;
+import org.thymeleaf.templateresolver.TemplateResolver;
+import uk.gov.register.presentation.config.RegistersConfiguration;
+import uk.gov.register.thymeleaf.ThymeleafResourceResolver;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class AssetsBundleCustomErrorHandler extends ErrorHandler {
+    private final Logger LOGGER = LoggerFactory.getLogger(AssetsBundleCustomErrorHandler.class);
+    private Environment environment;
+
+    public AssetsBundleCustomErrorHandler(Environment environment) {
+        this.environment = environment;
+    }
+
+    @Override
+    public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
+        baseRequest.setHandled(true);
+
+        TemplateResolver templateResolver = new TemplateResolver();
+        templateResolver.setResourceResolver(new ThymeleafResourceResolver());
+        templateResolver.setPrefix("/templates/");
+        templateResolver.setTemplateMode("HTML5");
+        templateResolver.setCacheable(false);
+        templateResolver.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        TemplateEngine engine = new TemplateEngine();
+        engine.setTemplateResolver(templateResolver);
+
+        ServletContext sc = baseRequest.getContext();
+        ServiceLocator sl = ((ServletContainer) environment.getJerseyServletContainer()).getApplicationHandler().getServiceLocator();
+        assert (sl != null);
+        RegistersConfiguration rc = sl.getService(RegistersConfiguration.class);
+        assert (rc != null);
+        RegisterData rd = rc.getRegisterData(RegisterNameExtractor.extractRegisterName(request.getHeader("Host")));
+        assert (rd != null);
+
+        WebContext wc = new WebContext(request, response, sc,
+                request.getLocale());
+        wc.setVariable("register", rd.getRegister());
+
+        engine.process("404.html", wc, response.getWriter());
+    }
+}

--- a/src/main/java/uk/gov/register/presentation/AssetsBundleCustomErrorHandler.java
+++ b/src/main/java/uk/gov/register/presentation/AssetsBundleCustomErrorHandler.java
@@ -62,6 +62,7 @@ public class AssetsBundleCustomErrorHandler extends ErrorHandler {
         wc.setVariable("register", rd.getRegister());
         wc.setVariable("friendlyRegisterName", StringUtils.capitalize(registerName) + " register");
 
+        response.setHeader("Content-Type", "text/html; charset=UTF-8");
         engine.process("404.html", wc, response.getWriter());
     }
 }

--- a/src/main/java/uk/gov/register/presentation/AssetsBundleCustomErrorHandler.java
+++ b/src/main/java/uk/gov/register/presentation/AssetsBundleCustomErrorHandler.java
@@ -1,6 +1,7 @@
 package uk.gov.register.presentation;
 
 import io.dropwizard.setup.Environment;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.glassfish.hk2.api.ServiceLocator;
@@ -47,15 +48,15 @@ public class AssetsBundleCustomErrorHandler extends ErrorHandler {
 
         ServletContext sc = baseRequest.getContext();
         ServiceLocator sl = ((ServletContainer) environment.getJerseyServletContainer()).getApplicationHandler().getServiceLocator();
-        assert (sl != null);
         RegistersConfiguration rc = sl.getService(RegistersConfiguration.class);
-        assert (rc != null);
-        RegisterData rd = rc.getRegisterData(RegisterNameExtractor.extractRegisterName(request.getHeader("Host")));
-        assert (rd != null);
+        String registerId = RegisterNameExtractor.extractRegisterName(request.getHeader("Host"));
+        RegisterData rd = rc.getRegisterData(registerId);
+        String registerName = registerId.replace('-',' ');
 
         WebContext wc = new WebContext(request, response, sc,
                 request.getLocale());
         wc.setVariable("register", rd.getRegister());
+        wc.setVariable("friendlyRegisterName", StringUtils.capitalize(registerName) + " register");
 
         engine.process("404.html", wc, response.getWriter());
     }

--- a/src/main/java/uk/gov/register/presentation/app/PresentationApplication.java
+++ b/src/main/java/uk/gov/register/presentation/app/PresentationApplication.java
@@ -25,10 +25,7 @@ import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.server.ServerProperties;
 import org.skife.jdbi.v2.DBI;
 import uk.gov.organisation.client.GovukOrganisationClient;
-import uk.gov.register.presentation.ContentSecurityPolicyFilter;
-import uk.gov.register.presentation.ContentTypeOptionsFilter;
-import uk.gov.register.presentation.EntryConverter;
-import uk.gov.register.presentation.XssProtectionFilter;
+import uk.gov.register.presentation.*;
 import uk.gov.register.presentation.config.FieldsConfiguration;
 import uk.gov.register.presentation.config.PresentationConfiguration;
 import uk.gov.register.presentation.config.PublicBodiesConfiguration;
@@ -133,6 +130,8 @@ public class PresentationApplication extends Application<PresentationConfigurati
         jerseyEnvironment.register(ContentSecurityPolicyFilter.class);
         jerseyEnvironment.register(ContentTypeOptionsFilter.class);
         jerseyEnvironment.register(XssProtectionFilter.class);
+
+        environment.getApplicationContext().setErrorHandler(new AssetsBundleCustomErrorHandler(environment));
     }
 
     private void setCorsPreflight(MutableServletContextHandler applicationContext) {


### PR DESCRIPTION
It's a bit ugly really, as I'm duplicating the Thymeleaf artifacts which we already create in ThymeleafView/Resolver/Renderer. 

An alternative approach would be to [use CloudFront to mask 404s](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/custom-error-pages.html).

Ideally you'd want to have the Thymeleaf artifacts injected into the object, but the HK2 ServiceLocator is null at the point of Application.run() and the jetty.setErrorHandler takes a class instance, not a class.
