### PR TITLE
Display fields in the register register entry order

### DIFF
--- a/src/main/java/uk/gov/register/presentation/config/Register.java
+++ b/src/main/java/uk/gov/register/presentation/config/Register.java
@@ -5,16 +5,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Iterables;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.List;
 import java.util.Optional;
-import java.util.Set;
-import java.util.TreeSet;
 
 import static com.google.common.base.Predicates.equalTo;
 import static com.google.common.base.Predicates.not;
 
 public class Register {
     final String registerName;
-    final Set<String> fields;
+    final List<String> fields;
     final Optional<String> copyright;
     final String registry;
     final String text;
@@ -23,14 +22,14 @@ public class Register {
 
     @JsonCreator
     public Register(@JsonProperty("register") String registerName,
-                    @JsonProperty("fields") Set<String> fields,
+                    @JsonProperty("fields") List<String> fields,
                     @JsonProperty("copyright") String copyright,
                     @JsonProperty("registry") String registry,
                     @JsonProperty("text") String text,
                     @JsonProperty("phase") String phase) {
         this.registerName = registerName;
         this.phase = phase;
-        this.fields = new TreeSet<>(fields); // ensure sorted order
+        this.fields = fields;
         this.copyright = StringUtils.isNotEmpty(copyright) ? Optional.of(copyright) : Optional.empty();
         this.registry = registry;
         this.text = text;

--- a/src/main/resources/templates/fragments/entry-table.html
+++ b/src/main/resources/templates/fragments/entry-table.html
@@ -15,19 +15,20 @@
             </tr>
         </thead>
         <tbody>
-            <tr th:each="keyValue : ${content}">
+            <th:block th:each="field : ${register.fields}">
+                <tr th:if="${content.containsKey(field)}">
                 <td>
-                    <a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(keyValue.key, registerDomain)}"
-                       th:text="${keyValue.key}"></a>
+                    <a th:href="${@uk.gov.register.presentation.HtmlViewSupport@fieldLink(field, registerDomain)}"
+                       th:text="${field}"></a>
                 </td>
 
-                <td th:if="${keyValue.value.isLink()}">
-                    <a th:href="${keyValue.value.link()}" th:text="${keyValue.value.value}"></a>
+                <td th:if="${content.get(field).isLink()}">
+                    <a th:href="${content.get(field).link()}" th:text="${content.get(field).value}"></a>
                 </td>
 
-                <td th:if="${keyValue.value.isList()}" class="field-list field-list-in-table">
+                <td th:if="${content.get(field).isList()}" class="field-list field-list-in-table">
                     <ul>
-                        <th:block th:each="fieldValue : ${keyValue.value}">
+                        <th:block th:each="fieldValue : ${content.get(field)}">
                             <li th:if="${fieldValue.isLink()}">
                                 <a th:href="${fieldValue.link()}" th:text="${fieldValue.value}"></a>
                             </li>
@@ -36,8 +37,9 @@
                     </ul>
                 </td>
 
-                <td th:unless="${keyValue.value.isLink() || keyValue.value.isList()}" th:text="${keyValue.value.value}"></td>
-            </tr>
+                <td th:unless="${content.get(field).isLink() || content.get(field).isList()}" th:text="${content.get(field).value}"></td>
+                </tr>
+            </th:block>
         </tbody>
     </table>
 </div>

--- a/src/test/java/uk/gov/register/presentation/config/RegisterTest.java
+++ b/src/test/java/uk/gov/register/presentation/config/RegisterTest.java
@@ -1,6 +1,6 @@
 package uk.gov.register.presentation.config;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
 import org.hamcrest.collection.IsIterableContainingInOrder;
 import org.junit.Test;
 
@@ -8,20 +8,20 @@ import static org.junit.Assert.assertThat;
 
 public class RegisterTest {
     @Test
-    public void getFields_returnsFieldsInSortedOrder() throws Exception {
-        Register register = new Register("address", ImmutableSet.of("address", "street", "postcode", "area", "property"), "", "", "", "alpha");
+    public void getFields_returnsFieldsInConfiguredOrder() throws Exception {
+        Register register = new Register("address", ImmutableList.of("address", "street", "postcode", "area", "property"), "", "", "", "alpha");
 
         Iterable<String> fields = register.getFields();
 
-        assertThat(fields, IsIterableContainingInOrder.contains("address", "area", "postcode", "property", "street"));
+        assertThat(fields, IsIterableContainingInOrder.contains("address", "street", "postcode", "area", "property"));
     }
 
     @Test
-    public void getNonPrimaryFields_returnsFieldsOtherThanPrimaryInSortedOrder() throws Exception {
-        Register register = new Register("company", ImmutableSet.of("address", "company", "secretary", "company-status", "company-accounts-category"), "", "", "", "alpha");
+    public void getNonPrimaryFields_returnsFieldsOtherThanPrimaryInConfiguredOrder() throws Exception {
+        Register register = new Register("company", ImmutableList.of("address", "company", "secretary", "company-status", "company-accounts-category"), "", "", "", "alpha");
 
         Iterable<String> fields = register.getNonPrimaryFields();
 
-        assertThat(fields, IsIterableContainingInOrder.contains("address", "company-accounts-category", "company-status", "secretary"));
+        assertThat(fields, IsIterableContainingInOrder.contains("address","secretary", "company-status", "company-accounts-category"));
     }
 }

--- a/src/test/java/uk/gov/register/presentation/view/HomePageViewTest.java
+++ b/src/test/java/uk/gov/register/presentation/view/HomePageViewTest.java
@@ -3,7 +3,6 @@ package uk.gov.register.presentation.view;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.internal.util.collections.Sets;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.register.presentation.config.Register;
 import uk.gov.register.presentation.resource.RequestContext;
@@ -11,6 +10,7 @@ import uk.gov.register.presentation.resource.RequestContext;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.Collections;
 
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
@@ -27,7 +27,7 @@ public class HomePageViewTest {
         HomePageView homePageView = new HomePageView(null, null, mockRequestContext, 1, 2, null, "openregister.org");
 
         String registerText = "foo *bar* [baz](/quux)";
-        when(mockRequestContext.getRegister()).thenReturn(new Register("", Sets.newSet(), "", "", registerText, "alpha"));
+        when(mockRequestContext.getRegister()).thenReturn(new Register("", Collections.emptyList(), "", "", registerText, "alpha"));
 
         String result = homePageView.getRegisterText();
 

--- a/src/test/resources/fixtures/list.csv
+++ b/src/test/resources/fixtures/list.csv
@@ -1,3 +1,3 @@
-entry,copyright,fields,phase,register,registry,text
-2,,field1;field2,,value2,,The Entry 2
-1,,field1,,value1,,The Entry 1
+entry,register,text,registry,phase,copyright,fields
+2,value2,The Entry 2,,,,field1;field2
+1,value1,The Entry 1,,,,field1

--- a/src/test/resources/fixtures/list.tsv
+++ b/src/test/resources/fixtures/list.tsv
@@ -1,3 +1,3 @@
-entry	copyright	fields	phase	register	registry	text
-2		field1;field2		value2		The Entry 2
-1		field1		value1		The Entry 1
+entry	register	text	registry	phase	copyright	fields
+2	value2	The Entry 2				field1;field2
+1	value1	The Entry 1				field1

--- a/src/test/resources/fixtures/list.ttl
+++ b/src/test/resources/fixtures/list.ttl
@@ -1,11 +1,11 @@
 @prefix field: <http://field.test.register.gov.uk/field/>.
 
 <http://register.beta.openregister.org/entry/2>
- field:fields <http://field.test.register.gov.uk/field/field1> ;
- field:fields <http://field.test.register.gov.uk/field/field2> ;
  field:register <http://register.test.register.gov.uk/register/value2> ;
- field:text "The Entry 2" .
-<http://register.beta.openregister.org/entry/1>
+ field:text "The Entry 2" ;
  field:fields <http://field.test.register.gov.uk/field/field1> ;
+ field:fields <http://field.test.register.gov.uk/field/field2> .
+<http://register.beta.openregister.org/entry/1>
  field:register <http://register.test.register.gov.uk/register/value1> ;
- field:text "The Entry 1" .
+ field:text "The Entry 1" ;
+ field:fields <http://field.test.register.gov.uk/field/field1> .

--- a/src/test/resources/fixtures/single.csv
+++ b/src/test/resources/fixtures/single.csv
@@ -1,2 +1,2 @@
-entry,copyright,fields,phase,register,registry,text
-1,,field1,,value1,,The Entry 1
+entry,register,text,registry,phase,copyright,fields
+1,value1,The Entry 1,,,,field1

--- a/src/test/resources/fixtures/single.tsv
+++ b/src/test/resources/fixtures/single.tsv
@@ -1,2 +1,2 @@
-entry	copyright	fields	phase	register	registry	text
-1		field1		value1		The Entry 1
+entry	register	text	registry	phase	copyright	fields
+1	value1	The Entry 1				field1

--- a/src/test/resources/fixtures/single.ttl
+++ b/src/test/resources/fixtures/single.ttl
@@ -1,6 +1,6 @@
 @prefix field: <http://field.test.register.gov.uk/field/>.
 
 <http://register.beta.openregister.org/entry/1>
- field:fields <http://field.test.register.gov.uk/field/field1> ;
  field:register <http://register.test.register.gov.uk/register/value1> ;
- field:text "The Entry 1" .
+ field:text "The Entry 1" ;
+ field:fields <http://field.test.register.gov.uk/field/field1> .


### PR DESCRIPTION
Currently, we display fields in alphabetical order, possibly pulling the
primary key to the front.  This results in oddities such as pulling
`end-date` near the front and pushing `start-date` near the end.

The register register entry for a register, which defines which fields a
register has, happens to also have a reasonably sensible order of
fields.  We had been working on the assumption that this order is not
significant but it now seems that this order is nicer than any sorted
order would be.

In particular, every entry in the register register identifies the
primary field first before listing other fields.  I've kept our code
which pulls the primary key to the front for the moment but we could
perhaps replace it by just trusting the order in the register register.
