### PR TITLE
Use registers & fields config from S3

### DIFF
--- a/deploy/scripts/start-service.sh
+++ b/deploy/scripts/start-service.sh
@@ -7,5 +7,9 @@ ENV=$(aws ec2 describe-tags --filters Name=resource-id,Values=$INSTANCE_ID Name=
 CONFIG_BUCKET=openregister.${ENV}.config
 
 aws s3 cp s3://${CONFIG_BUCKET}/${REGISTER_NAME}/presentation/config.yaml /srv/presentation --region eu-west-1
+aws s3 cp s3://${CONFIG_BUCKET}/registers.yaml /srv/presentation --region eu-west-1
+aws s3 cp s3://${CONFIG_BUCKET}/fields.yaml /srv/presentation --region eu-west-1
+
 docker run --name=presentationApp -d -p 80:8080 --volume /srv/presentation:/srv/presentation \
-    jstepien/openjdk8 java -Dfile.encoding=utf-8 -jar /srv/presentation/presentation.jar server /srv/presentation/config.yaml
+    jstepien/openjdk8 java -Dfile.encoding=utf-8 -DregistersYaml=/srv/presentation/registers.yaml -DfieldsYaml=/srv/presentation/fields.yaml \
+    -jar /srv/presentation/presentation.jar server /srv/presentation/config.yaml


### PR DESCRIPTION
Similar to openregister/mint@717bcdfa4f255229520.  The files are already
available and in use by the mint in each environment.  We already
introduced the ability to configure a path for the registers yaml file
in e00c2402e20fb0.  This just updates the deployment scripts to be able
to actually get the files from S3 and point presentation at them.
