### PR TITLE
ignore all unknown fields in register/field config

### DIFF
--- a/src/main/java/uk/gov/register/presentation/RegisterData.java
+++ b/src/main/java/uk/gov/register/presentation/RegisterData.java
@@ -1,6 +1,7 @@
 package uk.gov.register.presentation;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -10,6 +11,7 @@ import uk.gov.register.presentation.config.Register;
 
 import java.util.Map;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class RegisterData {
     final ObjectMapper yamlObjectMapper = Jackson.newObjectMapper(new YAMLFactory());
 

--- a/src/main/java/uk/gov/register/presentation/config/Field.java
+++ b/src/main/java/uk/gov/register/presentation/config/Field.java
@@ -8,7 +8,7 @@ import uk.gov.register.presentation.Cardinality;
 
 import java.util.Optional;
 
-@JsonIgnoreProperties({"phase"})
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Field {
     final String fieldName;
     final String datatype;

--- a/src/main/java/uk/gov/register/presentation/config/FieldsConfiguration.java
+++ b/src/main/java/uk/gov/register/presentation/config/FieldsConfiguration.java
@@ -21,7 +21,7 @@ public class FieldsConfiguration {
         return fields.stream().filter(f -> Objects.equals(f.fieldName, fieldName)).findFirst().get();
     }
 
-    @JsonIgnoreProperties({"hash", "last-updated", "serial-number"})
+    @JsonIgnoreProperties(ignoreUnknown = true)
     private static class FieldData {
         @JsonProperty
         Field entry;

--- a/src/main/java/uk/gov/register/presentation/config/PublicBodiesConfiguration.java
+++ b/src/main/java/uk/gov/register/presentation/config/PublicBodiesConfiguration.java
@@ -26,7 +26,7 @@ public class PublicBodiesConfiguration {
         return publicBodies.stream().filter(f -> Objects.equals(f.getPublicBodyId(), publicBodyId)).findFirst().get();
     }
 
-    @JsonIgnoreProperties({"hash", "last-updated"})
+    @JsonIgnoreProperties(ignoreUnknown = true)
     private static class PublicBodyData {
         @JsonProperty
         PublicBody entry;

--- a/src/main/java/uk/gov/register/presentation/config/PublicBody.java
+++ b/src/main/java/uk/gov/register/presentation/config/PublicBody.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-@JsonIgnoreProperties({"text","crest","website","parent-bodies","official-colour","public-body-type"})
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PublicBody {
     private final String name;
     private final String publicBodyId;

--- a/src/main/java/uk/gov/register/presentation/config/Register.java
+++ b/src/main/java/uk/gov/register/presentation/config/Register.java
@@ -1,6 +1,7 @@
 package uk.gov.register.presentation.config;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Iterables;
 import org.apache.commons.lang3.StringUtils;
@@ -11,6 +12,7 @@ import java.util.Optional;
 import static com.google.common.base.Predicates.equalTo;
 import static com.google.common.base.Predicates.not;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Register {
     final String registerName;
     final List<String> fields;


### PR DESCRIPTION
Register consumers must be [forwards-compatible](http://openregister.github.io/specification/#forwards-compatibility).  As part of this,
they must implement the must-ignore rule.  The best description I have
seen of this rule comes from the [I-JSON RFC](https://tools.ietf.org/html/rfc7493#section-4.2):

```
It is frequently the case that changes to protocols are required
after they have been put in production.  Protocols that allow the
introduction of new protocol elements in a way that does not disrupt
the operation of existing software have proven advantageous in
practice.

This can be referred to as a "Must-Ignore" policy, meaning that when
an implementation encounters a protocol element that it does not
recognize, it should treat the rest of the protocol transaction as if
the new element simply did not appear, and in particular, the
implementation MUST NOT treat this as an error condition.  The
converse "Must-Understand" policy does not tolerate the introduction
of new protocol elements, and while this has proven necessary in
certain protocol designs, in general it has been found to be overly
restrictive and brittle.

A good way to support the use of Must-Ignore in I-JSON protocol
designs is to require that top-level protocol elements must be JSON
objects, and to specify that members whose names are unrecognized
MUST be ignored.
```

Prior to this commit, we were not forwards-compatible against the
introduction of new fields in the register register or the field
register.
