### PR TITLE
Render copyright text as markdown

### DIFF
--- a/src/main/java/uk/gov/register/presentation/view/HomePageView.java
+++ b/src/main/java/uk/gov/register/presentation/view/HomePageView.java
@@ -1,10 +1,9 @@
 package uk.gov.register.presentation.view;
 
-import org.markdownj.MarkdownProcessor;
+import uk.gov.organisation.client.GovukOrganisation;
 import uk.gov.register.presentation.LinkValue;
 import uk.gov.register.presentation.config.PublicBody;
 import uk.gov.register.presentation.resource.RequestContext;
-import uk.gov.organisation.client.GovukOrganisation;
 
 import java.time.Instant;
 import java.time.ZoneId;
@@ -13,8 +12,6 @@ import java.util.Optional;
 
 public class HomePageView extends AttributionView {
     private final static DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("d MMM uuuu").withZone(ZoneId.of("UTC"));
-
-    private final MarkdownProcessor markdownProcessor = new MarkdownProcessor();
 
     private final Instant lastUpdated;
     private final int totalRecords;

--- a/src/main/java/uk/gov/register/thymeleaf/ThymeleafView.java
+++ b/src/main/java/uk/gov/register/thymeleaf/ThymeleafView.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 public class ThymeleafView extends View {
     protected final RequestContext requestContext;
     private String thymeleafTemplateName;
-    private final MarkdownProcessor markdownProcessor = new MarkdownProcessor();
+    protected final MarkdownProcessor markdownProcessor = new MarkdownProcessor();
 
     public ThymeleafView(RequestContext requestContext, String templateName) {
         super(templateName, StandardCharsets.UTF_8);

--- a/src/main/java/uk/gov/register/thymeleaf/ThymeleafView.java
+++ b/src/main/java/uk/gov/register/thymeleaf/ThymeleafView.java
@@ -2,6 +2,7 @@ package uk.gov.register.thymeleaf;
 
 import io.dropwizard.views.View;
 import org.apache.commons.lang3.StringUtils;
+import org.markdownj.MarkdownProcessor;
 import uk.gov.register.presentation.EntryConverter;
 import uk.gov.register.presentation.EntryView;
 import uk.gov.register.presentation.config.Register;
@@ -11,10 +12,12 @@ import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 
 public class ThymeleafView extends View {
     protected final RequestContext requestContext;
     private String thymeleafTemplateName;
+    private final MarkdownProcessor markdownProcessor = new MarkdownProcessor();
 
     public ThymeleafView(RequestContext requestContext, String templateName) {
         super(templateName, StandardCharsets.UTF_8);
@@ -50,6 +53,12 @@ public class ThymeleafView extends View {
 
     public Register getRegister() {
         return requestContext.getRegister();
+    }
+
+    public Optional<String> getRenderedCopyrightText() {
+        return getRegister().getCopyright().map(
+                markdownProcessor::markdown
+        );
     }
 
     public EntryView getRegisterEntryView(EntryConverter entryConverter) {

--- a/src/main/resources/templates/400.html
+++ b/src/main/resources/templates/400.html
@@ -9,7 +9,7 @@
     <div th:replace="main.html::phase"></div>
     <h1>Bad Request</h1>
     <p th:text="${exception.message}"></p>
-    <p th:replace="copyright.html::copyright"></p>
+    <div th:replace="copyright.html::copyright"></div>
 </main>
 
 <footer th:replace="main.html::footer"></footer>

--- a/src/main/resources/templates/404.html
+++ b/src/main/resources/templates/404.html
@@ -9,7 +9,7 @@
     <div th:replace="main.html::phase"></div>
     <h1>Page not found</h1>
     <p>If you entered a web address please check it was correct.</p>
-    <p th:replace="copyright.html::copyright"></p>
+    <div th:replace="copyright.html::copyright"></div>
 </main>
 
 <footer th:replace="main.html::footer"></footer>

--- a/src/main/resources/templates/500.html
+++ b/src/main/resources/templates/500.html
@@ -9,7 +9,7 @@
     <div th:replace="main.html::phase"></div>
     <h1>Oops, looks like something went wrong</h1>
     <p>500 error.</p>
-    <p th:replace="copyright.html::copyright"></p>
+    <div th:replace="copyright.html::copyright"></div>
 </main>
 
 <footer th:replace="main.html::footer"></footer>

--- a/src/main/resources/templates/copyright.html
+++ b/src/main/resources/templates/copyright.html
@@ -1,4 +1,4 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
-<p th:fragment="copyright" class="registry-copyright" th:if="${register.copyright.present}" th:text="${register.copyright.get()}">Copyright text</p>
+<div th:fragment="copyright" class="registry-copyright" th:if="${renderedCopyrightText.present}" th:utext="${renderedCopyrightText.get()}">Copyright text</div>
 </html>

--- a/src/main/resources/templates/entry.html
+++ b/src/main/resources/templates/entry.html
@@ -25,7 +25,7 @@
 
     <p><a th:href="${versionHistoryLink}">View all versions of this record</a></p>
 
-    <p th:replace="copyright.html::copyright"></p>
+    <div th:replace="copyright.html::copyright"></div>
 
 </main>
 <footer th:replace="main.html::footer"></footer>

--- a/src/main/resources/templates/history.html
+++ b/src/main/resources/templates/history.html
@@ -26,7 +26,7 @@
         </tbody>
     </table>
 
-    <p th:replace="copyright.html::copyright"></p>
+    <div th:replace="copyright.html::copyright"></div>
 </main>
 <footer th:replace="main.html::footer"></footer>
 </body>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -55,7 +55,7 @@
         </div>
     </details>
 
-    <p th:replace="copyright.html::copyright">Copyright text</p>
+    <div th:replace="copyright.html::copyright">Copyright text</div>
 
         
 

--- a/src/main/resources/templates/latest-entry-of-record.html
+++ b/src/main/resources/templates/latest-entry-of-record.html
@@ -26,7 +26,7 @@
     <p><a th:href="${versionHistoryLink}">View all versions of this record</a>
     </p>
 
-    <p th:replace="copyright.html::copyright"></p>
+    <div th:replace="copyright.html::copyright"></div>
 </main>
 <footer th:replace="main.html::footer"></footer>
 </body>

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -57,10 +57,10 @@
         <div class="footer-meta">
             <div class="footer-meta-inner">
 
-                <div th:if="${register.copyright.present}" class="custom-government-licence">
-                    <p class="registry-copyright" th:text="${register.copyright.get()}">Copyright text</p>
+                <div th:if="${renderedCopyrightText.present}" class="custom-government-licence">
+                    <div th:replace="copyright.html::copyright">Copyright text</div>
                 </div>
-                <div th:unless="${register.copyright.present}" class="open-government-licence">
+                <div th:unless="${renderedCopyrightText.present}" class="open-government-licence">
                     <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
                                        rel="license">Open Government Licence</a></p>
 

--- a/src/test/java/uk/gov/register/presentation/functional/HomePageFunctionalTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/HomePageFunctionalTest.java
@@ -10,6 +10,7 @@ import javax.ws.rs.core.Response;
 import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertThat;
 
 public class HomePageFunctionalTest extends FunctionalTestBase {
@@ -21,6 +22,7 @@ public class HomePageFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void homepageHasXhtmlLangAttributes() throws Throwable {
+        cleanDatabaseRule.before();
         DBSupport.publishMessages("address", Collections.singletonList("{\"address\":\"1234\"}"));
         Response response = getRequest("/");
 
@@ -30,6 +32,35 @@ public class HomePageFunctionalTest extends FunctionalTestBase {
         assertThat(htmlElement.first().attr("lang"), equalTo("en"));
         assertThat(htmlElement.first().attr("xml:lang"), equalTo("en"));
 
+    }
+
+    @Test
+    public void homepageHasCopyrightInMainBodyRenderedAsMarkdown() throws Throwable {
+        // assumes that registers.yaml has a `postcode` entry with a copyright field containing markdown links
+        // might be good to find a way to specify this in the test
         cleanDatabaseRule.before();
+        DBSupport.publishMessages("postcode", Collections.singletonList("{\"postcode\":\"1234\"}"));
+
+        Response response = getRequest("postcode", "/");
+        Document doc = Jsoup.parse(response.readEntity(String.class));
+
+        Elements copyrightParagraph = doc.select("main .registry-copyright");
+        Elements links = copyrightParagraph.select("a");
+        assertThat(links.size(), greaterThan(0));
+    }
+
+    @Test
+    public void homepageHasCopyrightInFooterRenderedAsMarkdown() throws Throwable {
+        // assumes that registers.yaml has a `postcode` entry with a copyright field containing markdown links
+        // might be good to find a way to specify this in the test
+        cleanDatabaseRule.before();
+        DBSupport.publishMessages("postcode", Collections.singletonList("{\"postcode\":\"1234\"}"));
+
+        Response response = getRequest("postcode", "/");
+        Document doc = Jsoup.parse(response.readEntity(String.class));
+
+        Elements copyrightParagraph = doc.select("footer .registry-copyright");
+        Elements links = copyrightParagraph.select("a");
+        assertThat(links.size(), greaterThan(0));
     }
 }

--- a/src/test/java/uk/gov/register/thymeleaf/ThymeleafViewTest.java
+++ b/src/test/java/uk/gov/register/thymeleaf/ThymeleafViewTest.java
@@ -5,10 +5,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.register.presentation.config.Register;
 import uk.gov.register.presentation.resource.RequestContext;
 
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -27,5 +32,17 @@ public class ThymeleafViewTest {
         when(requestContext.getRegisterPrimaryKey()).thenReturn("company-limited-by-guarantee");
 
         assertThat(thymeleafView.getFriendlyRegisterName(), equalTo("Company limited by guarantee register"));
+    }
+
+    @Test
+    @SuppressWarnings("OptionalGetWithoutIsPresent, should always be present for this test")
+    public void getRenderedCopyrightText_returnsCopyrightRenderedAsMarkdown() throws Exception {
+        Register theRegister = mock(Register.class);
+        when(theRegister.getCopyright()).thenReturn(Optional.of("Copyright text [with link](http://www.example.com/copyright)"));
+        when(requestContext.getRegister()).thenReturn(theRegister);
+
+        String renderedCopyrightText = thymeleafView.getRenderedCopyrightText().get();
+
+        assertThat(renderedCopyrightText, containsString("<p>Copyright text <a href=\"http://www.example.com/copyright\">with link</a></p>"));
     }
 }


### PR DESCRIPTION
The copyright field is defined to be markdown, and for the postcode
register the data is markdown.  This updates the copyright text to be
rendered as markdown.

Copyright text can appear in the main body or on the footer.  I've
written tests to catch both cases.

We are already rendering markdown on the front page from the register
`text` field, so this was relatively simple to add.
