### PR TITLE
Item resource

### DIFF
--- a/create_schema.sh
+++ b/create_schema.sh
@@ -18,4 +18,8 @@ CREATE TABLE IF NOT EXISTS total_entries(count INTEGER, last_updated TIMESTAMP W
 
 insert into total_entries (count) select 0 where not exists (select count from total_entries);
 
+create table if not exists item (sha256hex varchar primary key, content jsonb);
+
+create table if not exists entry (entry_number integer primary key, sha256hex varchar, timestamp timestamp without time zone default now());
+
 "

--- a/drop_schema.sh
+++ b/drop_schema.sh
@@ -12,6 +12,10 @@ DROP TABLE IF EXISTS ordered_entry_index;
 
 DROP TABLE IF EXISTS total_entries;
 
+DROP TABLE IF EXISTS item;
+
+DROP TABLE IF EXISTS entry;
+
 DROP TABLE IF EXISTS sth; -- TODO: no longer used, should be deleted after a while
 
 "

--- a/src/main/java/uk/gov/register/presentation/EntryConverter.java
+++ b/src/main/java/uk/gov/register/presentation/EntryConverter.java
@@ -48,7 +48,7 @@ public class EntryConverter {
         );
     }
 
-    private FieldValue convert(Map.Entry<String, JsonNode> mapEntry) {
+    public FieldValue convert(Map.Entry<String, JsonNode> mapEntry) {
         String fieldName = mapEntry.getKey();
         JsonNode value = mapEntry.getValue();
         FieldConverter fieldConverter = new FieldConverter(fieldsConfiguration.getField(fieldName));

--- a/src/main/java/uk/gov/register/presentation/app/PresentationApplication.java
+++ b/src/main/java/uk/gov/register/presentation/app/PresentationApplication.java
@@ -31,6 +31,7 @@ import uk.gov.register.presentation.config.FieldsConfiguration;
 import uk.gov.register.presentation.config.PresentationConfiguration;
 import uk.gov.register.presentation.config.PublicBodiesConfiguration;
 import uk.gov.register.presentation.config.RegistersConfiguration;
+import uk.gov.register.presentation.dao.ItemDAO;
 import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
 import uk.gov.register.presentation.representations.ExtraMediaType;
 import uk.gov.register.presentation.resource.RequestContext;
@@ -78,6 +79,7 @@ public class PresentationApplication extends Application<PresentationConfigurati
         DBIFactory dbiFactory = new DBIFactory();
         DBI jdbi = dbiFactory.build(environment, configuration.getDatabase(), "postgres");
         RecentEntryIndexQueryDAO queryDAO = jdbi.onDemand(RecentEntryIndexQueryDAO.class);
+        ItemDAO itemDAO = jdbi.onDemand(ItemDAO.class);
 
         JerseyEnvironment jerseyEnvironment = environment.jersey();
         DropwizardResourceConfig resourceConfig = jerseyEnvironment.getResourceConfig();
@@ -98,7 +100,7 @@ public class PresentationApplication extends Application<PresentationConfigurati
             @Override
             protected void configure() {
                 bind(queryDAO).to(RecentEntryIndexQueryDAO.class);
-
+                bind(itemDAO).to(ItemDAO.class);
                 bind(new FieldsConfiguration(Optional.ofNullable(System.getProperty("fieldsYaml")))).to(FieldsConfiguration.class);
                 bind(new RegistersConfiguration(Optional.ofNullable(System.getProperty("registersYaml")))).to(RegistersConfiguration.class);
                 bind(new PublicBodiesConfiguration(Optional.ofNullable(System.getProperty("publicBodiesYaml")))).to(PublicBodiesConfiguration.class);
@@ -112,7 +114,7 @@ public class PresentationApplication extends Application<PresentationConfigurati
             }
         });
 
-        resourceConfig.packages("uk.gov.register.presentation.representations","uk.gov.register.presentation.resource");
+        resourceConfig.packages("uk.gov.register.presentation.representations", "uk.gov.register.presentation.resource");
 
         MutableServletContextHandler applicationContext = environment.getApplicationContext();
 

--- a/src/main/java/uk/gov/register/presentation/dao/Item.java
+++ b/src/main/java/uk/gov/register/presentation/dao/Item.java
@@ -1,0 +1,13 @@
+package uk.gov.register.presentation.dao;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class Item{
+    private final String sha256hex;
+    public final JsonNode content;
+
+    public Item(String sha256hex, JsonNode content) {
+        this.sha256hex = sha256hex;
+        this.content = content;
+    }
+}

--- a/src/main/java/uk/gov/register/presentation/dao/ItemDAO.java
+++ b/src/main/java/uk/gov/register/presentation/dao/ItemDAO.java
@@ -1,0 +1,42 @@
+package uk.gov.register.presentation.dao;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.jackson.Jackson;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
+import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+
+import java.io.IOException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+
+public interface ItemDAO {
+
+    @SqlQuery("select * from item where sha256hex=:sha256hex")
+    @SingleValueResult(Item.class)
+    @RegisterMapper(ItemMapper.class)
+    Optional<Item> getItemBySHA256(@Bind("sha256hex") String sha256Hash);
+
+    class ItemMapper implements ResultSetMapper<Item> {
+
+        private final ObjectMapper objectMapper;
+
+        public ItemMapper() {
+            objectMapper = Jackson.newObjectMapper();
+        }
+
+        @Override
+        public Item map(int index, ResultSet r, StatementContext ctx) throws SQLException {
+            try {
+                return new Item(r.getString("sha256hex"), objectMapper.readValue(r.getString("content"), JsonNode.class));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/src/main/java/uk/gov/register/presentation/resource/ItemResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/ItemResource.java
@@ -3,7 +3,9 @@ package uk.gov.register.presentation.resource;
 import org.postgresql.util.PSQLException;
 import uk.gov.register.presentation.dao.Item;
 import uk.gov.register.presentation.dao.ItemDAO;
+import uk.gov.register.presentation.representations.ExtraMediaType;
 import uk.gov.register.presentation.view.ItemView;
+import uk.gov.register.presentation.view.ViewFactory;
 
 import javax.inject.Inject;
 import javax.ws.rs.*;
@@ -12,16 +14,18 @@ import java.util.Optional;
 
 @Path("/item")
 public class ItemResource {
+    private final ViewFactory viewFactory;
     private final ItemDAO itemDAO;
 
     @Inject
-    public ItemResource(ItemDAO itemDAO) {
+    public ItemResource(ViewFactory viewFactory, ItemDAO itemDAO) {
+        this.viewFactory = viewFactory;
         this.itemDAO = itemDAO;
     }
 
     @GET
     @Path("/{sha256hash: sha-256:.*}")
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON})
     public ItemView getItemBySHA256Hash(@PathParam("sha256hash") String sha256Hash) {
         Optional<Item> item;
         try {
@@ -33,6 +37,6 @@ public class ItemResource {
             }
             throw e;
         }
-        return item.map(ItemView::new).orElseThrow(NotFoundException::new);
+        return item.map(viewFactory::getItemView).orElseThrow(NotFoundException::new);
     }
 }

--- a/src/main/java/uk/gov/register/presentation/resource/ItemResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/ItemResource.java
@@ -1,0 +1,38 @@
+package uk.gov.register.presentation.resource;
+
+import org.postgresql.util.PSQLException;
+import uk.gov.register.presentation.dao.Item;
+import uk.gov.register.presentation.dao.ItemDAO;
+import uk.gov.register.presentation.view.ItemView;
+
+import javax.inject.Inject;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import java.util.Optional;
+
+@Path("/item")
+public class ItemResource {
+    private final ItemDAO itemDAO;
+
+    @Inject
+    public ItemResource(ItemDAO itemDAO) {
+        this.itemDAO = itemDAO;
+    }
+
+    @GET
+    @Path("/{sha256hash: sha-256:.*}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public ItemView getItemBySHA256Hash(@PathParam("sha256hash") String sha256Hash) {
+        Optional<Item> item;
+        try {
+            item = itemDAO.getItemBySHA256(sha256Hash.replaceAll("(sha-256:)(.*)", "$2"));
+        } catch (Throwable e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof PSQLException && ((PSQLException) cause).getSQLState().equals("42P01")) {
+                throw new NotFoundException();
+            }
+            throw e;
+        }
+        return item.map(ItemView::new).orElseThrow(NotFoundException::new);
+    }
+}

--- a/src/main/java/uk/gov/register/presentation/resource/ItemResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/ItemResource.java
@@ -1,5 +1,6 @@
 package uk.gov.register.presentation.resource;
 
+import io.dropwizard.jersey.caching.CacheControl;
 import org.postgresql.util.PSQLException;
 import uk.gov.register.presentation.dao.Item;
 import uk.gov.register.presentation.dao.ItemDAO;
@@ -26,6 +27,7 @@ public class ItemResource {
     @GET
     @Path("/{sha256hash: sha-256:.*}")
     @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON})
+    @CacheControl(immutable = true)
     public ItemView getItemBySHA256Hash(@PathParam("sha256hash") String sha256Hash) {
         Optional<Item> item;
         try {

--- a/src/main/java/uk/gov/register/presentation/resource/ItemResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/ItemResource.java
@@ -2,36 +2,62 @@ package uk.gov.register.presentation.resource;
 
 import io.dropwizard.jersey.caching.CacheControl;
 import org.postgresql.util.PSQLException;
+import uk.gov.register.presentation.DbEntry;
 import uk.gov.register.presentation.dao.Item;
 import uk.gov.register.presentation.dao.ItemDAO;
+import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
 import uk.gov.register.presentation.representations.ExtraMediaType;
+import uk.gov.register.presentation.view.AttributionView;
 import uk.gov.register.presentation.view.ItemView;
+import uk.gov.register.presentation.view.SingleEntryView;
 import uk.gov.register.presentation.view.ViewFactory;
 
 import javax.inject.Inject;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import java.util.Optional;
+import java.util.function.Function;
 
 @Path("/item")
 public class ItemResource {
     private final ViewFactory viewFactory;
     private final ItemDAO itemDAO;
+    private final RecentEntryIndexQueryDAO queryDAO;
+    private final RequestContext requestContext;
+
 
     @Inject
-    public ItemResource(ViewFactory viewFactory, ItemDAO itemDAO) {
+    public ItemResource(ViewFactory viewFactory, RequestContext requestContext, ItemDAO itemDAO, RecentEntryIndexQueryDAO queryDAO) {
         this.viewFactory = viewFactory;
         this.itemDAO = itemDAO;
+        this.queryDAO = queryDAO;
+        this.requestContext = requestContext;
     }
 
     @GET
-    @Path("/{sha256hash: sha-256:.*}")
+    @Path("/{item-hash}")
     @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON})
     @CacheControl(immutable = true)
-    public ItemView getItemBySHA256Hash(@PathParam("sha256hash") String sha256Hash) {
+    public AttributionView getItemByHex(@PathParam("item-hash") String itemHash) {
+        String sha256Regex = "(sha-256:)(.*)";
+        if(itemHash.matches(sha256Regex)){
+            return getItemBySHA256(itemHash.replaceAll(sha256Regex, "$2"));
+        }else{
+            return getItemByHash(itemHash);
+        }
+
+    }
+
+    @Deprecated
+    private SingleEntryView getItemByHash(String itemHash) {
+        Optional<DbEntry> entryO = queryDAO.findEntryByHash(itemHash);
+        return entryResponse(entryO, viewFactory::getSingleEntryView);
+    }
+
+    private ItemView getItemBySHA256(String sha256Hash) {
         Optional<Item> item;
         try {
-            item = itemDAO.getItemBySHA256(sha256Hash.replaceAll("(sha-256:)(.*)", "$2"));
+            item = itemDAO.getItemBySHA256(sha256Hash);
         } catch (Throwable e) {
             Throwable cause = e.getCause();
             if (cause instanceof PSQLException && ((PSQLException) cause).getSQLState().equals("42P01")) {
@@ -40,5 +66,16 @@ public class ItemResource {
             throw e;
         }
         return item.map(viewFactory::getItemView).orElseThrow(NotFoundException::new);
+    }
+
+    private SingleEntryView entryResponse(Optional<DbEntry> optionalEntry, Function<DbEntry, SingleEntryView> convertToEntryView) {
+        SingleEntryView singleEntryView = optionalEntry.map(convertToEntryView)
+                .orElseThrow(NotFoundException::new);
+
+        requestContext.
+                getHttpServletResponse().
+                setHeader("Link", String.format("<%s>;rel=\"version-history\"", singleEntryView.getVersionHistoryLink()));
+
+        return singleEntryView;
     }
 }

--- a/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
@@ -44,16 +44,6 @@ public class SearchResource {
         return viewFactory.getRecordsView(records, pagination);
     }
 
-    @Deprecated
-    @GET
-    @Path("/item/{item-hash}")
-    @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
-    @CacheControl(immutable = true)
-    public SingleEntryView findByItemHash(@PathParam("item-hash") String itemHash) {
-        Optional<DbEntry> entryO = queryDAO.findEntryByHash(itemHash);
-        return entryResponse(entryO, viewFactory::getSingleEntryView);
-    }
-
     @GET
     @Path("/entry/{entry-number}")
     @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})

--- a/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/SearchResource.java
@@ -44,6 +44,7 @@ public class SearchResource {
         return viewFactory.getRecordsView(records, pagination);
     }
 
+    @Deprecated
     @GET
     @Path("/item/{item-hash}")
     @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})

--- a/src/main/java/uk/gov/register/presentation/view/ItemView.java
+++ b/src/main/java/uk/gov/register/presentation/view/ItemView.java
@@ -2,17 +2,32 @@ package uk.gov.register.presentation.view;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.JsonNode;
+import uk.gov.organisation.client.GovukOrganisation;
+import uk.gov.register.presentation.EntryConverter;
+import uk.gov.register.presentation.FieldValue;
+import uk.gov.register.presentation.config.PublicBody;
 import uk.gov.register.presentation.dao.Item;
+import uk.gov.register.presentation.resource.RequestContext;
 
-public class ItemView {
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class ItemView extends AttributionView {
+    private EntryConverter itemConverter;
     private Item item;
 
-    public ItemView(Item item) {
+    ItemView(RequestContext requestContext, PublicBody custodian, Optional<GovukOrganisation.Details> branding, EntryConverter itemConverter, Item item) {
+        super(requestContext, custodian, branding, "item.html");
+        this.itemConverter = itemConverter;
         this.item = item;
     }
 
     @JsonValue
-    public JsonNode getItem() {
-        return item.content;
+    public Map<String, FieldValue> getContent() {
+        Stream<Map.Entry<String, JsonNode>> fieldStream = StreamSupport.stream(((Iterable<Map.Entry<String, JsonNode>>) item.content::fields).spliterator(), false);
+        return fieldStream.collect(Collectors.toMap(Map.Entry::getKey, itemConverter::convert));
     }
 }

--- a/src/main/java/uk/gov/register/presentation/view/ItemView.java
+++ b/src/main/java/uk/gov/register/presentation/view/ItemView.java
@@ -1,0 +1,18 @@
+package uk.gov.register.presentation.view;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.JsonNode;
+import uk.gov.register.presentation.dao.Item;
+
+public class ItemView {
+    private Item item;
+
+    public ItemView(Item item) {
+        this.item = item;
+    }
+
+    @JsonValue
+    public JsonNode getItem() {
+        return item.content;
+    }
+}

--- a/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
+++ b/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
@@ -9,6 +9,7 @@ import uk.gov.register.presentation.Version;
 import uk.gov.register.presentation.config.PublicBodiesConfiguration;
 import uk.gov.register.presentation.config.PublicBody;
 import uk.gov.register.presentation.config.RegisterDomainConfiguration;
+import uk.gov.register.presentation.dao.Item;
 import uk.gov.register.presentation.resource.Pagination;
 import uk.gov.register.presentation.resource.RequestContext;
 import uk.gov.register.thymeleaf.ThymeleafView;
@@ -87,6 +88,10 @@ public class ViewFactory {
 
     public ListVersionView listVersionView(List<Version> versions) throws Exception {
         return new ListVersionView(requestContext, getCustodian(), getBranding(), versions);
+    }
+
+    public ItemView getItemView(Item item){
+        return new ItemView(requestContext, getCustodian(), getBranding(), entryConverter, item);
     }
 
     private PublicBody getCustodian() {

--- a/src/main/resources/templates/item.html
+++ b/src/main/resources/templates/item.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+
+<html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<head th:include="main.html::head"></head>
+<body>
+<header th:replace="main.html::header"></header>
+<main id="main" role="main">
+    <div th:replace="main.html::phase"></div>
+    <div class="grid-row">
+        <div class="column-two-thirds">
+        </div>
+        <div class="column-third" th:include="main.html :: attribution"></div>
+    </div>
+
+    <div th:include="fragments/entry-table.html :: entry-table (content = ${content})"></div>
+
+    <div th:include="data-formats.html::data-formats"></div>
+
+    <div th:replace="copyright.html::copyright"></div>
+
+</main>
+<footer th:replace="main.html::footer"></footer>
+</body>
+</html>

--- a/src/test/java/uk/gov/register/presentation/functional/FindEntityTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/FindEntityTest.java
@@ -7,7 +7,6 @@ import org.jsoup.nodes.Document;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
-import uk.gov.register.presentation.functional.testSupport.DBSupport;
 
 import javax.ws.rs.core.Response;
 
@@ -34,9 +33,23 @@ public class FindEntityTest extends FunctionalTestBase {
     }
 
     @Test
-    public void findByItemHash_shouldReturnEntryForTheGivenHash() throws Exception {
+    public void findByEntryNumber_shouldReturnEntryForTheGivenEntryNumber() throws Exception {
         Response response = getRequest("/entry/2.json");
 
+        assertThat(response.getStatus(), equalTo(200));
+        assertThat(response.getHeaderString("Link"), equalTo("</address/6789/history>;rel=\"version-history\""));
+        JSONAssert.assertEquals("{" +
+                "\"serial-number\":2," +
+                "\"hash\":\"hash2\"," +
+                "\"entry\":{\"name\":\"presley\",\"address\":\"6789\"}}"
+                , response.readEntity(String.class), false);
+    }
+
+    @Test
+    public void findByItemHash_shouldReturnEntryForTheGivenItemHash() throws Exception {
+        Response response = getRequest("/item/hash2.json");
+
+        assertThat(response.getStatus(), equalTo(200));
         assertThat(response.getHeaderString("Link"), equalTo("</address/6789/history>;rel=\"version-history\""));
         JSONAssert.assertEquals("{" +
                 "\"serial-number\":2," +

--- a/src/test/java/uk/gov/register/presentation/functional/HomePageFunctionalTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/HomePageFunctionalTest.java
@@ -22,7 +22,7 @@ public class HomePageFunctionalTest extends FunctionalTestBase {
     @Test
     public void homepageHasXhtmlLangAttributes() throws Throwable {
         cleanDatabaseRule.before();
-        dbSupport.publishMessages("address", Collections.singletonList("{\"address\":\"1234\"}"));
+        dbSupport.publishMessages("address", Collections.singletonList("{\"hash\":\"hash1\",\"entry\":{\"address\":\"1234\"}}"));
         Response response = getRequest("/");
 
         Document doc = Jsoup.parse(response.readEntity(String.class));
@@ -38,7 +38,7 @@ public class HomePageFunctionalTest extends FunctionalTestBase {
         // assumes that registers.yaml has a `postcode` entry with a copyright field containing markdown links
         // might be good to find a way to specify this in the test
         cleanDatabaseRule.before();
-        dbSupport.publishMessages("postcode", Collections.singletonList("{\"postcode\":\"1234\"}"));
+        dbSupport.publishMessages("postcode", Collections.singletonList("{\"hash\":\"hash1\",\"entry\":{\"postcode\":\"1234\"}}"));
 
         Response response = getRequest("postcode", "/");
         Document doc = Jsoup.parse(response.readEntity(String.class));
@@ -53,7 +53,7 @@ public class HomePageFunctionalTest extends FunctionalTestBase {
         // assumes that registers.yaml has a `postcode` entry with a copyright field containing markdown links
         // might be good to find a way to specify this in the test
         cleanDatabaseRule.before();
-        dbSupport.publishMessages("postcode", Collections.singletonList("{\"postcode\":\"1234\"}"));
+        dbSupport.publishMessages("postcode", Collections.singletonList("{\"hash\":\"hash1\",\"entry\":{\"postcode\":\"1234\"}}"));
 
         Response response = getRequest("postcode", "/");
         Document doc = Jsoup.parse(response.readEntity(String.class));

--- a/src/test/java/uk/gov/register/presentation/functional/ItemResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/ItemResourceFunctionalTest.java
@@ -39,9 +39,7 @@ public class ItemResourceFunctionalTest extends FunctionalTestBase {
 
     @Test
     public void return404ResponseWhenItemNotExist() throws JSONException {
-        String sha256Hex = DigestUtils.sha256Hex(item1);
-
-        Response response = getRequest("/item/sha256:" + sha256Hex);
+        Response response = getRequest("/item/sha-256:notExistHexValue");
 
         assertThat(response.getStatus(), equalTo(404));
     }

--- a/src/test/java/uk/gov/register/presentation/functional/ItemResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/ItemResourceFunctionalTest.java
@@ -12,7 +12,7 @@ import javax.ws.rs.core.Response;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class ItemResourceTest extends FunctionalTestBase {
+public class ItemResourceFunctionalTest extends FunctionalTestBase {
     static String item1 = "{\"address\":\"6789\",\"name\":\"presley\"}";
     static String item2 = "{\"address\":\"145678\",\"name\":\"ellis\"}";
 
@@ -26,7 +26,7 @@ public class ItemResourceTest extends FunctionalTestBase {
     }
 
     @Test
-    public void getItemBySha256Hash() throws JSONException {
+    public void jsonRepresentationOfAnItem() throws JSONException {
         String sha256Hex = DigestUtils.sha256Hex(item1);
 
         Response response = getRequest(String.format("/item/sha-256:%s.json", sha256Hex));

--- a/src/test/java/uk/gov/register/presentation/functional/ItemResourceFunctionalTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/ItemResourceFunctionalTest.java
@@ -32,6 +32,7 @@ public class ItemResourceFunctionalTest extends FunctionalTestBase {
         Response response = getRequest(String.format("/item/sha-256:%s.json", sha256Hex));
 
         assertThat(response.getStatus(), equalTo(200));
+        assertThat(response.getHeaders().get("cache-control").toString(), equalTo("[no-transform, max-age=31536000]"));
 
         JSONAssert.assertEquals(item1, response.readEntity(String.class), false);
     }

--- a/src/test/java/uk/gov/register/presentation/functional/ItemResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/ItemResourceTest.java
@@ -29,7 +29,7 @@ public class ItemResourceTest extends FunctionalTestBase {
     public void getItemBySha256Hash() throws JSONException {
         String sha256Hex = DigestUtils.sha256Hex(item1);
 
-        Response response = getRequest("/item/sha-256:" + sha256Hex);
+        Response response = getRequest(String.format("/item/sha-256:%s.json", sha256Hex));
 
         assertThat(response.getStatus(), equalTo(200));
 

--- a/src/test/java/uk/gov/register/presentation/functional/ItemResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/functional/ItemResourceTest.java
@@ -1,0 +1,58 @@
+package uk.gov.register.presentation.functional;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.json.JSONException;
+import org.junit.Before;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import javax.ws.rs.core.Response;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ItemResourceTest extends FunctionalTestBase {
+    static String item1 = "{\"address\":\"6789\",\"name\":\"presley\"}";
+    static String item2 = "{\"address\":\"145678\",\"name\":\"ellis\"}";
+
+    @Before
+    public void publishTestMessages() throws Throwable {
+        cleanDatabaseRule.before();
+        dbSupport.publishMessages(ImmutableList.of(
+                String.format("{\"hash\":\"hash1\",\"entry\":%s}", item1),
+                String.format("{\"hash\":\"hash2\",\"entry\":%s}", item2)
+        ));
+    }
+
+    @Test
+    public void getItemBySha256Hash() throws JSONException {
+        String sha256Hex = DigestUtils.sha256Hex(item1);
+
+        Response response = getRequest("/item/sha-256:" + sha256Hex);
+
+        assertThat(response.getStatus(), equalTo(200));
+
+        JSONAssert.assertEquals(item1, response.readEntity(String.class), false);
+    }
+
+    @Test
+    public void return404ResponseWhenItemNotExist() throws JSONException {
+        String sha256Hex = DigestUtils.sha256Hex(item1);
+
+        Response response = getRequest("/item/sha256:" + sha256Hex);
+
+        assertThat(response.getStatus(), equalTo(404));
+    }
+
+    //Note: tests below are valid till migration is in progress, delete after migration and respective code in ItemResource
+    @Test
+    public void return404ResponseWhenItemTableNotExist() {
+        testDAO.testItemDAO.dropTable();
+        String sha256Hex = DigestUtils.sha256Hex(item1);
+
+        Response response = getRequest("/item/sha-256:" + sha256Hex);
+
+        assertThat(response.getStatus(), equalTo(404));
+    }
+}

--- a/src/test/java/uk/gov/register/presentation/functional/testSupport/CleanDatabaseRule.java
+++ b/src/test/java/uk/gov/register/presentation/functional/testSupport/CleanDatabaseRule.java
@@ -15,11 +15,15 @@ public class CleanDatabaseRule extends ExternalResource {
         testDAO.testCurrentKeyDAO.dropTable();
         testDAO.testTotalEntryDAO.dropTable();
         testDAO.testTotalRecordDAO.dropTable();
+        testDAO.testItemDAO.dropTable();
+        testDAO.testEntryDAO.dropTable();
 
         testDAO.testEntryIndexDAO.createTable();
         testDAO.testCurrentKeyDAO.createTable();
         testDAO.testTotalEntryDAO.createTable();
         testDAO.testTotalRecordDAO.createTable();
+        testDAO.testItemDAO.createTable();
+        testDAO.testEntryDAO.createTable();
     }
 
 }

--- a/src/test/java/uk/gov/register/presentation/functional/testSupport/TestDAO.java
+++ b/src/test/java/uk/gov/register/presentation/functional/testSupport/TestDAO.java
@@ -9,6 +9,9 @@ public class TestDAO {
     public final TestTotalEntryDAO testTotalEntryDAO;
     public final TestTotalRecordDAO testTotalRecordDAO;
 
+    public final TestItemDAO testItemDAO;
+    public final TestEntryDAO testEntryDAO;
+
     private TestDAO(String databaseName, String user) {
         String postgresConnectionString = String.format("jdbc:postgresql://localhost:5432/%s?user=%s", databaseName, user);
         DBI dbi = new DBI(postgresConnectionString);
@@ -17,6 +20,8 @@ public class TestDAO {
         this.testCurrentKeyDAO = handle.attach(TestCurrentKeyDAO.class);
         this.testTotalEntryDAO = handle.attach(TestTotalEntryDAO.class);
         this.testTotalRecordDAO = handle.attach(TestTotalRecordDAO.class);
+        this.testItemDAO = handle.attach(TestItemDAO.class);
+        this.testEntryDAO = handle.attach(TestEntryDAO.class);
     }
 
     public static TestDAO get(String databaseName, String user) {

--- a/src/test/java/uk/gov/register/presentation/functional/testSupport/TestEntryDAO.java
+++ b/src/test/java/uk/gov/register/presentation/functional/testSupport/TestEntryDAO.java
@@ -1,0 +1,15 @@
+package uk.gov.register.presentation.functional.testSupport;
+
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+
+public interface TestEntryDAO {
+    @SqlUpdate("drop table if exists entry")
+    void dropTable();
+
+    @SqlUpdate("create table if not exists entry (entry_number integer primary key, sha256hex varchar, timestamp timestamp without time zone default now())")
+    void createTable();
+
+    @SqlUpdate("insert into entry(entry_number, sha256hex) values(:entry_number, :sha256hex)")
+    void insert(@Bind("entry_number")int serialNumber,@Bind("sha256hex") String sha256);
+}

--- a/src/test/java/uk/gov/register/presentation/functional/testSupport/TestItemDAO.java
+++ b/src/test/java/uk/gov/register/presentation/functional/testSupport/TestItemDAO.java
@@ -1,0 +1,33 @@
+package uk.gov.register.presentation.functional.testSupport;
+
+import org.postgresql.util.PGobject;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+
+import java.sql.SQLException;
+
+public abstract class TestItemDAO {
+    @SqlUpdate("drop table if exists item")
+    public abstract void dropTable();
+
+    @SqlUpdate("create table if not exists item (sha256hex varchar primary key, content jsonb)")
+    public abstract void createTable();
+
+    @SqlUpdate("delete from item where sha256hex=:sha256hex; insert into item(sha256hex, content) values(:sha256hex, :content)")
+    public abstract void __insertIfNotExist(@Bind("sha256hex") String sha256, @Bind("content") PGobject item);
+
+    public void insertIfNotExist(String sha256, String item) {
+        __insertIfNotExist(sha256, pgObject(item));
+    }
+
+    private PGobject pgObject(String entry) {
+        try {
+            PGobject pGobject = new PGobject();
+            pGobject.setType("jsonb");
+            pGobject.setValue(entry);
+            return pGobject;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
@@ -58,17 +58,6 @@ public class SearchResourceTest {
     }
 
     @Test
-    public void findByItemHash_throwsNotFoundWhenHashIsNotFound() {
-        when(queryDAO.findEntryByHash("123")).thenReturn(Optional.<DbEntry>empty());
-        try {
-            resource.findByItemHash("123");
-            fail("Must fail");
-        } catch (NotFoundException e) {
-            //success
-        }
-    }
-
-    @Test
     public void findBySerial_findsEntryFromDb() throws Exception {
         DbEntry abcd = new DbEntry(52, new DbContent("abcd", Jackson.newObjectMapper().readTree("{\"school\":\"9001\",\"address\":\"1234\"}")));
         when(queryDAO.findEntryBySerialNumber(52)).thenReturn(Optional.of(abcd));
@@ -119,16 +108,6 @@ public class SearchResourceTest {
     public void findSupportsTurtleHtmlAndJson() throws Exception {
         Method searchMethod = SearchResource.class.getDeclaredMethod("find", String.class, String.class);
         List<String> declaredMediaTypes = asList(searchMethod.getDeclaredAnnotation(Produces.class).value());
-        assertThat(declaredMediaTypes,
-                hasItems(ExtraMediaType.TEXT_HTML,
-                        MediaType.APPLICATION_JSON,
-                        ExtraMediaType.TEXT_TTL));
-    }
-
-    @Test
-    public void findByItemHashSupportsTurtleHtmlAndJson() throws Exception {
-        Method findByItemHashMethod = SearchResource.class.getDeclaredMethod("findByItemHash", String.class);
-        List<String> declaredMediaTypes = asList(findByItemHashMethod.getDeclaredAnnotation(Produces.class).value());
         assertThat(declaredMediaTypes,
                 hasItems(ExtraMediaType.TEXT_HTML,
                         MediaType.APPLICATION_JSON,


### PR DESCRIPTION
Introducing new item resource.

It reads from new schema which might not be available in an environment, In such cases a 404 is returned. Once the schema with migrated data is available, the resource will start serving the content.

Currently EntryConverter is used to convert an item in to html displayable format, this inconsistency will be resolved once we start working on new Entry resource story.
