### PR TITLE
Render json format as only other available data representation for new resources.

### DIFF
--- a/src/main/resources/templates/data-formats.html
+++ b/src/main/resources/templates/data-formats.html
@@ -10,5 +10,10 @@
         <a th:href="${@uk.gov.register.presentation.HtmlViewSupport@representationLink(#httpServletRequest, 'ttl')}">ttl</a>
     </p>
 </div>
+<div th:fragment="new-data-formats">
+    <p class="data-representations">This data is available as:
+        <a th:href="${@uk.gov.register.presentation.HtmlViewSupport@representationLink(#httpServletRequest, 'json')}">json</a>
+    </p>
+</div>
 </html>
 

--- a/src/main/resources/templates/item.html
+++ b/src/main/resources/templates/item.html
@@ -8,13 +8,14 @@
     <div th:replace="main.html::phase"></div>
     <div class="grid-row">
         <div class="column-two-thirds">
+            <p></p>
         </div>
         <div class="column-third" th:include="main.html :: attribution"></div>
     </div>
 
     <div th:include="fragments/entry-table.html :: entry-table (content = ${content})"></div>
 
-    <div th:include="data-formats.html::data-formats"></div>
+    <div th:include="data-formats.html::new-data-formats"></div>
 
     <div th:replace="copyright.html::copyright"></div>
 

--- a/src/main/resources/templates/new-entries.html
+++ b/src/main/resources/templates/new-entries.html
@@ -30,7 +30,7 @@
 
     <nav th:replace="pagination.html::pagination-bottom"></nav>
 
-    <div th:include="data-formats.html::data-formats"></div>
+    <div th:include="data-formats.html::new-data-formats"></div>
 </main>
 
 <footer th:replace="main.html::footer"></footer>

--- a/src/main/resources/templates/new-entry.html
+++ b/src/main/resources/templates/new-entry.html
@@ -21,7 +21,7 @@
 
     <div th:include="fragments/new-entry-table.html :: new-entry-table (entry = ${entry})"></div>
 
-    <div th:include="data-formats.html::data-formats"></div>
+    <div th:include="data-formats.html::new-data-formats"></div>
 
     <div th:replace="copyright.html::copyright"></div>
 


### PR DESCRIPTION
New resource only has Json representation available other than html, so available data-formats in footer only shows json.
