### PR TITLE
Disable link to public-body register

### DIFF
--- a/src/main/java/uk/gov/register/presentation/HtmlViewSupport.java
+++ b/src/main/java/uk/gov/register/presentation/HtmlViewSupport.java
@@ -23,8 +23,4 @@ public class HtmlViewSupport {
     public static String fieldLink(String fieldName, String registerDomain) {
         return new LinkValue("field", registerDomain, fieldName).link();
     }
-
-    public static String publicBodyLink(String fieldName, String registerDomain) {
-        return new LinkValue("public-body", registerDomain, fieldName).link();
-    }
 }

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -41,8 +41,8 @@
 </div>
 
 <th:block th:fragment="organisation(organisation, branding)">
-    <a th:if="${branding.present}" th:href="${@uk.gov.register.presentation.HtmlViewSupport@publicBodyLink(organisation.publicBodyId, registerDomain)}" th:utext="${#strings.replace(branding.get().logoFormattedName,'\r\n','&lt;br/&gt;')}" class="organisation-logo" th:classappend="|organisation-logo-${branding.get().logoClassName} ${branding.get().colourClassName}|">Cabinet Office</a>
-    <a th:unless="${branding.present}" th:href="${@uk.gov.register.presentation.HtmlViewSupport@publicBodyLink(organisation.publicBodyId, registerDomain)}" th:text="${organisation.name}" class="organisation-logo organisation-logo-no-identity">Cabinet Office</a>
+    <span th:if="${branding.present}" th:utext="${#strings.replace(branding.get().logoFormattedName,'\r\n','&lt;br/&gt;')}" class="organisation-logo" th:classappend="|organisation-logo-${branding.get().logoClassName} ${branding.get().colourClassName}|">Cabinet Office</span>
+    <span th:unless="${branding.present}" th:text="${organisation.name}" class="organisation-logo organisation-logo-no-identity">Cabinet Office</span>
 </th:block>
 
 <div th:fragment="attribution">


### PR DESCRIPTION
This register isn't ready for prime time, so we should disable linking
to it.

We still use the official-colour and logo type from the
public-bodies.yaml and the PublicBodiesConfiguration so they can be
kept around.
