### PR TITLE
Use java.time.Instant in preference to java.sql.Timestamp

### DIFF
--- a/src/main/java/uk/gov/register/presentation/dao/Entry.java
+++ b/src/main/java/uk/gov/register/presentation/dao/Entry.java
@@ -5,25 +5,20 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 
-import java.sql.Timestamp;
-import java.text.SimpleDateFormat;
-import java.time.ZoneId;
-import java.util.TimeZone;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 
 public class Entry {
-    private final static SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-    static {
-        simpleDateFormat.setTimeZone(TimeZone.getTimeZone(ZoneId.of("UTC")));
-    }
-
     @JsonProperty("entry-number")
     public final String entryNumber;
 
     private final String sha256hex;
 
-    private final Timestamp timestamp;
+    private final Instant timestamp;
 
-    public Entry(String entryNumber, String sha256hex, Timestamp timestamp) {
+    public Entry(String entryNumber, String sha256hex, Instant timestamp) {
         this.entryNumber = entryNumber;
         this.sha256hex = sha256hex;
         this.timestamp = timestamp;
@@ -36,7 +31,8 @@ public class Entry {
 
     @JsonProperty("entry-timestamp")
     public String getTimestamp() {
-        return simpleDateFormat.format(timestamp);
+        // http://openregister.github.io/specification/#timestamp-datatype only allows seconds, not fractions thereof
+        return ISO_INSTANT.format(timestamp.truncatedTo(ChronoUnit.SECONDS));
     }
 
     public static CsvSchema csvSchema() {

--- a/src/main/java/uk/gov/register/presentation/dao/NewEntryMapper.java
+++ b/src/main/java/uk/gov/register/presentation/dao/NewEntryMapper.java
@@ -9,6 +9,6 @@ import java.sql.SQLException;
 public class NewEntryMapper implements ResultSetMapper<Entry> {
     @Override
     public Entry map(int index, ResultSet r, StatementContext ctx) throws SQLException {
-        return new Entry(r.getString("entry_number"), r.getString("sha256hex"), r.getTimestamp("timestamp"));
+        return new Entry(r.getString("entry_number"), r.getString("sha256hex"), r.getTimestamp("timestamp").toInstant());
     }
 }

--- a/src/main/java/uk/gov/register/presentation/dao/RecordDAO.java
+++ b/src/main/java/uk/gov/register/presentation/dao/RecordDAO.java
@@ -48,7 +48,7 @@ public abstract class RecordDAO {
                         new Entry(
                                 r.getString("entry_number"),
                                 r.getString("sha256hex"),
-                                r.getTimestamp("timestamp")
+                                r.getTimestamp("timestamp").toInstant()
                         ),
                         new Item(
                                 r.getString("sha256hex"),

--- a/src/test/java/uk/gov/register/presentation/dao/EntryTest.java
+++ b/src/test/java/uk/gov/register/presentation/dao/EntryTest.java
@@ -2,7 +2,7 @@ package uk.gov.register.presentation.dao;
 
 import org.junit.Test;
 
-import java.sql.Timestamp;
+import java.time.Instant;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -10,13 +10,13 @@ import static org.junit.Assert.assertThat;
 public class EntryTest {
     @Test
     public void getTimestamp_returnsTheFormattedTimestamp() {
-        Entry entry = new Entry("123", "abc", new Timestamp(1459241964336L));
+        Entry entry = new Entry("123", "abc", Instant.ofEpochMilli(1459241964336L));
         assertThat(entry.getTimestamp(), equalTo("2016-03-29T08:59:24Z"));
     }
 
     @Test
     public void getSha256hex_returnsTheSha256HexOfItem() {
-        Entry entry = new Entry("123", "abc", new Timestamp(1459241964336L));
+        Entry entry = new Entry("123", "abc", Instant.ofEpochMilli(1459241964336L));
         assertThat(entry.getSha256hex(), equalTo("sha-256:abc"));
     }
 }

--- a/src/test/java/uk/gov/register/presentation/representations/NewCsvWriterTest.java
+++ b/src/test/java/uk/gov/register/presentation/representations/NewCsvWriterTest.java
@@ -13,12 +13,12 @@ import uk.gov.register.presentation.view.NewEntryListView;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Optional;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -32,7 +32,7 @@ public class NewCsvWriterTest {
     public void writes_NewEntryListView_to_output_stream() throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         csvWriter.writeTo(new NewEntryListView(null,null,null, Optional.empty(),
-                ImmutableList.of(new Entry("1","1234abcd",new Timestamp(1400000000000L)))),
+                ImmutableList.of(new Entry("1","1234abcd", Instant.ofEpochSecond(1400000000L)))),
                 NewEntryListView.class,
                 null,
                 null,

--- a/src/test/java/uk/gov/register/presentation/view/RecordViewTest.java
+++ b/src/test/java/uk/gov/register/presentation/view/RecordViewTest.java
@@ -9,7 +9,7 @@ import uk.gov.register.presentation.dao.Item;
 import uk.gov.register.presentation.dao.Record;
 
 import java.io.IOException;
-import java.sql.Timestamp;
+import java.time.Instant;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -19,7 +19,7 @@ public class RecordViewTest {
     public void recordJsonRepresentation_isFlatJsonOfEntryAndItemContent() throws IOException, JSONException {
         ObjectMapper objectMapper = Jackson.newObjectMapper();
 
-        Record record = new Record(new Entry("1", "ab", new Timestamp(1459241964336L)), new Item("ab", objectMapper.readTree("{\"a\":\"b\"}")));
+        Record record = new Record(new Entry("1", "ab", Instant.ofEpochMilli(1459241964336L)), new Item("ab", objectMapper.readTree("{\"a\":\"b\"}")));
         RecordView recordView = new RecordView(null, null, null, null, record);
 
         String result = objectMapper.writeValueAsString(recordView);


### PR DESCRIPTION
The new java time API is nice in all sorts of ways.  In particular, a
java.time.Instant object is immutable, whereas java.sql.Timestamp has
methods like setTime().

We should use the java.time API in our domain model, and convert to
java.sql objects only when interacting with the database.
