### PR TITLE
remove explicit html format URL

### DIFF
--- a/src/main/java/uk/gov/register/presentation/HtmlViewSupport.java
+++ b/src/main/java/uk/gov/register/presentation/HtmlViewSupport.java
@@ -7,8 +7,7 @@ import java.util.Map;
 @SuppressWarnings("unused, methods of this class are used from html")
 public class HtmlViewSupport {
     public static String representationLink(HttpServletRequest httpServletRequest, String representation) {
-        String representationUrlSuffix = representation.equals("html") ? "" : "." + representation;
-        String requestPath = httpServletRequest.getRequestURI().replaceAll("([^\\.]+)(\\.[a-z]+)?", "$1" + representationUrlSuffix);
+        String requestPath = httpServletRequest.getRequestURI().replaceAll("([^\\.]+)(\\.[a-z]+)?", "$1." + representation);
 
         UriBuilder uriBuilder = UriBuilder.fromPath(requestPath);
 

--- a/src/main/resources/templates/data-formats.html
+++ b/src/main/resources/templates/data-formats.html
@@ -4,7 +4,6 @@
     <p class="data-representations">This data is available as:
         <a th:href="${@uk.gov.register.presentation.HtmlViewSupport@representationLink(#httpServletRequest, 'json')}">json</a>,
         <a th:href="${@uk.gov.register.presentation.HtmlViewSupport@representationLink(#httpServletRequest, 'yaml')}">yaml</a>,
-        <a th:href="${@uk.gov.register.presentation.HtmlViewSupport@representationLink(#httpServletRequest, 'html')}">html</a>,
         <a th:href="${@uk.gov.register.presentation.HtmlViewSupport@representationLink(#httpServletRequest, 'csv')}">csv</a>,
         <a th:href="${@uk.gov.register.presentation.HtmlViewSupport@representationLink(#httpServletRequest, 'tsv')}">tsv </a> and
         <a th:href="${@uk.gov.register.presentation.HtmlViewSupport@representationLink(#httpServletRequest, 'ttl')}">ttl</a>
@@ -14,7 +13,6 @@
     <p class="data-representations">This data is available as:
         <a th:href="${@uk.gov.register.presentation.HtmlViewSupport@representationLink(#httpServletRequest, 'json')}">json</a>,
         <a th:href="${@uk.gov.register.presentation.HtmlViewSupport@representationLink(#httpServletRequest, 'yaml')}">yaml</a>,
-        <a th:href="${@uk.gov.register.presentation.HtmlViewSupport@representationLink(#httpServletRequest, 'html')}">html</a>,
         <a th:href="${@uk.gov.register.presentation.HtmlViewSupport@representationLink(#httpServletRequest, 'csv')}">csv</a> and
         <a th:href="${@uk.gov.register.presentation.HtmlViewSupport@representationLink(#httpServletRequest, 'tsv')}">tsv</a>
     </p>

--- a/src/test/java/uk/gov/register/presentation/HtmlViewSupportTest.java
+++ b/src/test/java/uk/gov/register/presentation/HtmlViewSupportTest.java
@@ -33,12 +33,4 @@ public class HtmlViewSupportTest {
         String link = HtmlViewSupport.representationLink(servletRequest, "csv");
         assertThat(link, equalTo("/item/hashvalue.csv?query=value"));
     }
-
-    @Test
-    public void representationLink_doNotAddRepresentationSuffixForHTMLRepresentation() throws URISyntaxException {
-        when(servletRequest.getRequestURI()).thenReturn("/item/hashvalue.json");
-        when(servletRequest.getParameterMap()).thenReturn(Collections.singletonMap("query", new String[]{"value"}));
-        String link = HtmlViewSupport.representationLink(servletRequest, "html");
-        assertThat(link, equalTo("/item/hashvalue?query=value"));
-    }
 }


### PR DESCRIPTION
I don't think we really need an explicit link to the html
representation.  If you're reading this text you've already got the html
content.
