### PR TITLE
Fix technical details link

### DIFF
--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -35,7 +35,7 @@
         <div class="column-third">
             <ul>
                 <li><a href="http://www.openregister.org/">About registers</a></li>
-                <li><a href="http://www.openregister.org/developer">Developer documentation</a></li>
+                <li><a href="http://openregister.github.io/specification/">Register specification</a></li>
                 <li><a href="/download">Download all entries</a></li>
             </ul>
         </div>


### PR DESCRIPTION
We had a link to "developer documentation" but it was only ever a
placeholder.  If people want more technical details they could go and
look at the specification instead, which is a much more complete and
useful document.
