### PR TITLE
Restructure DAO methods in respective DAO classes

### DIFF
--- a/src/main/java/uk/gov/register/presentation/dao/EntryDAO.java
+++ b/src/main/java/uk/gov/register/presentation/dao/EntryDAO.java
@@ -1,10 +1,12 @@
 package uk.gov.register.presentation.dao;
 
+import io.dropwizard.java8.jdbi.args.InstantMapper;
 import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper;
 import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -17,5 +19,12 @@ public interface EntryDAO {
     @SqlQuery("select * from entry ORDER BY entry_number desc limit :limit offset :offset")
     @RegisterMapper(NewEntryMapper.class)
     List<Entry> getEntries(@Bind("limit") long maxNumberToFetch, @Bind("offset") long offset);
+
+    @RegisterMapper(InstantMapper.class)
+    @SqlQuery("SELECT timestamp FROM entry ORDER BY entry_number DESC LIMIT 1")
+    Instant getLastUpdatedTime();
+
+    @SqlQuery("SELECT count FROM total_entries")
+    int getTotalEntries();
 }
 

--- a/src/main/java/uk/gov/register/presentation/dao/RecentEntryIndexQueryDAO.java
+++ b/src/main/java/uk/gov/register/presentation/dao/RecentEntryIndexQueryDAO.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import io.dropwizard.jackson.Jackson;
-import io.dropwizard.java8.jdbi.args.InstantMapper;
 import org.postgresql.util.PGobject;
 import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
@@ -14,7 +13,6 @@ import uk.gov.register.presentation.DbEntry;
 import uk.gov.register.presentation.mapper.EntryMapper;
 
 import java.sql.SQLException;
-import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -52,16 +50,6 @@ public abstract class RecentEntryIndexQueryDAO {
             "SELECT serial_number FROM current_keys ORDER BY serial_number DESC LIMIT :limit OFFSET :offset" +
             ") ORDER BY serial_number DESC")
     public abstract List<DbEntry> getLatestEntriesOfRecords(@Bind("limit") long maxNumberToFetch, @Bind("offset") long offset);
-
-    @SqlQuery("SELECT count FROM total_entries")
-    public abstract int getTotalEntries();
-
-    @RegisterMapper(InstantMapper.class)
-    @SqlQuery("SELECT timestamp FROM entry ORDER BY entry_number DESC LIMIT 1")
-    public abstract Instant getLastUpdatedTime();
-
-    @SqlQuery("SELECT count FROM total_records")
-    public abstract int getTotalRecords();
 
     public List<DbEntry> findAllEntriesByKeyValue(String key, String value) throws Exception {
         Object entry = ImmutableMap.of("entry", ImmutableMap.of(key, value));

--- a/src/main/java/uk/gov/register/presentation/dao/RecordDAO.java
+++ b/src/main/java/uk/gov/register/presentation/dao/RecordDAO.java
@@ -23,6 +23,9 @@ public abstract class RecordDAO {
 
     private static final ObjectMapper objectMapper = Jackson.newObjectMapper();
 
+    @SqlQuery("SELECT count FROM total_records")
+    public abstract int getTotalRecords();
+
     @SqlQuery("select entry_number, timestamp, e.sha256hex as sha256hex, content from entry e, item i where e.sha256hex=i.sha256hex and e.entry_number = (select serial_number from current_keys where current_keys.key=:key)")
     @SingleValueResult(Record.class)
     @RegisterMapper(RecordMapper.class)

--- a/src/main/java/uk/gov/register/presentation/resource/EntryResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/EntryResource.java
@@ -3,7 +3,6 @@ package uk.gov.register.presentation.resource;
 import io.dropwizard.jersey.caching.CacheControl;
 import uk.gov.register.presentation.dao.Entry;
 import uk.gov.register.presentation.dao.EntryDAO;
-import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
 import uk.gov.register.presentation.representations.ExtraMediaType;
 import uk.gov.register.presentation.view.AttributionView;
 import uk.gov.register.presentation.view.ViewFactory;
@@ -18,14 +17,12 @@ public class EntryResource extends ResourceCommon {
 
     private final EntryDAO entryDAO;
     private final ViewFactory viewFactory;
-    private final RecentEntryIndexQueryDAO queryDAO;
 
     @Inject
-    public EntryResource(EntryDAO entryDAO, ViewFactory viewFactory, RecentEntryIndexQueryDAO queryDAO, RequestContext requestContext) {
+    public EntryResource(EntryDAO entryDAO, ViewFactory viewFactory, RequestContext requestContext) {
         super(requestContext);
         this.entryDAO = entryDAO;
         this.viewFactory = viewFactory;
-        this.queryDAO = queryDAO;
     }
 
     @GET
@@ -41,7 +38,7 @@ public class EntryResource extends ResourceCommon {
     @Path("/entries")
     @Produces({ExtraMediaType.TEXT_HTML, MediaType.APPLICATION_JSON, ExtraMediaType.TEXT_YAML, ExtraMediaType.TEXT_CSV, ExtraMediaType.TEXT_TSV, ExtraMediaType.TEXT_TTL})
     public AttributionView entries(@QueryParam(Pagination.INDEX_PARAM) Optional<Long> pageIndex, @QueryParam(Pagination.SIZE_PARAM) Optional<Long> pageSize) {
-        Pagination pagination = new Pagination(pageIndex, pageSize, queryDAO.getTotalEntries());
+        Pagination pagination = new Pagination(pageIndex, pageSize, entryDAO.getTotalEntries());
 
         setNextAndPreviousPageLinkHeader(pagination);
 

--- a/src/main/java/uk/gov/register/presentation/resource/HomePageResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/HomePageResource.java
@@ -1,7 +1,8 @@
 package uk.gov.register.presentation.resource;
 
 import io.dropwizard.views.View;
-import uk.gov.register.presentation.dao.RecentEntryIndexQueryDAO;
+import uk.gov.register.presentation.dao.EntryDAO;
+import uk.gov.register.presentation.dao.RecordDAO;
 import uk.gov.register.presentation.representations.ExtraMediaType;
 import uk.gov.register.presentation.view.ViewFactory;
 
@@ -14,18 +15,20 @@ import javax.ws.rs.core.MediaType;
 @Path("/")
 public class HomePageResource {
     private final ViewFactory viewFactory;
-    private final RecentEntryIndexQueryDAO recentEntryIndexQueryDAO;
+    private final RecordDAO recordDAO;
+    private EntryDAO entryDAO;
 
     @Inject
-    public HomePageResource(ViewFactory viewFactory, RecentEntryIndexQueryDAO recentEntryIndexQueryDAO) {
+    public HomePageResource(ViewFactory viewFactory, RecordDAO recordDAO, EntryDAO entryDAO) {
         this.viewFactory = viewFactory;
-        this.recentEntryIndexQueryDAO = recentEntryIndexQueryDAO;
+        this.recordDAO = recordDAO;
+        this.entryDAO = entryDAO;
     }
 
     @GET
     @Produces({ExtraMediaType.TEXT_HTML})
     public View home() {
-        return viewFactory.homePageView(recentEntryIndexQueryDAO.getTotalRecords(), recentEntryIndexQueryDAO.getTotalEntries(), recentEntryIndexQueryDAO.getLastUpdatedTime());
+        return viewFactory.homePageView(recordDAO.getTotalRecords(), entryDAO.getTotalEntries(), entryDAO.getLastUpdatedTime());
     }
 
     @GET


### PR DESCRIPTION
Moving DAO methods from old schema `RecentEntryIndexQueryDAO`  class to new DAO classes so that it is easy to understand about which methods are actually used and then gradually remove their usage and finally delete the old schema.
