### PR TITLE
Clearer record entries page

### DIFF
--- a/src/main/java/uk/gov/register/presentation/resource/RecordResource.java
+++ b/src/main/java/uk/gov/register/presentation/resource/RecordResource.java
@@ -48,8 +48,8 @@ public class RecordResource {
         if (allEntries.isEmpty()) {
             throw new NotFoundException();
         }
-        return viewFactory.getEntriesView(
-                allEntries,
+        return viewFactory.getRecordEntriesView(
+                key, allEntries,
                 new Pagination(Optional.of(1), Optional.of(allEntries.size()), allEntries.size())
         );
     }

--- a/src/main/java/uk/gov/register/presentation/view/EntryListView.java
+++ b/src/main/java/uk/gov/register/presentation/view/EntryListView.java
@@ -14,11 +14,20 @@ import java.util.Optional;
 public class EntryListView extends CsvRepresentationView {
     private IPagination pagination;
     private Collection<Entry> entries;
+    private final Optional<String> recordKey;
 
     public EntryListView(RequestContext requestContext, IPagination pagination, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, Collection<Entry> entries) {
         super(requestContext, custodian, custodianBranding, "entries.html");
         this.pagination = pagination;
         this.entries = entries;
+        this.recordKey = Optional.empty();
+    }
+
+    public EntryListView(RequestContext requestContext, IPagination pagination, PublicBody custodian, Optional<GovukOrganisation.Details> custodianBranding, Collection<Entry> entries, String recordKey) {
+        super(requestContext, custodian, custodianBranding, "entries.html");
+        this.pagination = pagination;
+        this.entries = entries;
+        this.recordKey = Optional.of(recordKey);
     }
 
     @JsonValue
@@ -30,6 +39,9 @@ public class EntryListView extends CsvRepresentationView {
     public IPagination getPagination() {
         return pagination;
     }
+
+    @SuppressWarnings("unused, used from templates")
+    public Optional<String> getRecordKey() { return recordKey; }
 
     @Override
     public CsvRepresentation<Collection<Entry>> csvRepresentation() {

--- a/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
+++ b/src/main/java/uk/gov/register/presentation/view/ViewFactory.java
@@ -71,6 +71,10 @@ public class ViewFactory {
         return new EntryListView(requestContext, pagination, getCustodian(), getBranding(), entries);
     }
 
+    public EntryListView getRecordEntriesView(String recordKey, Collection<Entry> entries, IPagination pagination) {
+        return new EntryListView(requestContext, pagination, getCustodian(), getBranding(), entries, recordKey);
+    }
+
     public RecordView getRecordView(Record record) {
         return new RecordView(requestContext, getCustodian(), getBranding(), itemConverter, record);
     }

--- a/src/main/resources/templates/entries.html
+++ b/src/main/resources/templates/entries.html
@@ -7,7 +7,10 @@
 <main id="main" role="main">
     <div th:replace="main.html::phase"></div>
     <div class="grid-row">
-        <div class="column-two-thirds" th:include="pagination.html::pagination-top('entries')"></div>
+        <div class="column-two-thirds">
+            <div th:include="pagination.html::pagination-top('entries')"></div>
+            <div th:if="${recordKey.present}">Part of <a th:href="${'/record/' + recordKey.get()}" th:text="${'Record: ' + recordKey.get()}">Record: GM</a></div>
+        </div>
         <div class="column-third" th:include="main.html :: attribution"></div>
     </div>
 


### PR DESCRIPTION
After this change, the record entries page (eg
https://country.register.gov.uk/record/GM/entries ) will have some extra
text indicating which record the entries correspond to.  For example:

1 entries
Part of [Record:400673](http://school.openregister.dev:8080/record/400673)

The old entries page /entries remains unchanged.

Original design by @stephenjoe1.

<img width="1068" alt="screen shot 2016-06-16 at 14 23 31" src="https://cloud.githubusercontent.com/assets/581269/16118638/f3e935c0-33cf-11e6-87c2-40b2eb3416a5.png">
<img width="1048" alt="screen shot 2016-06-16 at 14 23 40" src="https://cloud.githubusercontent.com/assets/581269/16118639/f61145fe-33cf-11e6-91bc-c47001860951.png">
