### PR TITLE
RFC: Make scheme explicitly configurable (default https)

### DIFF
--- a/src/main/java/uk/gov/register/presentation/HtmlViewSupport.java
+++ b/src/main/java/uk/gov/register/presentation/HtmlViewSupport.java
@@ -19,7 +19,7 @@ public class HtmlViewSupport {
         return uriBuilder.build().toString();
     }
 
-    public static String fieldLink(String fieldName, String registerDomain, String requestScheme) {
-        return new LinkValue("field", registerDomain, requestScheme, fieldName).link();
+    public static String fieldLink(String fieldName, String registerDomain, String scheme) {
+        return new LinkValue("field", registerDomain, scheme, fieldName).link();
     }
 }

--- a/src/main/java/uk/gov/register/presentation/config/PresentationConfiguration.java
+++ b/src/main/java/uk/gov/register/presentation/config/PresentationConfiguration.java
@@ -27,12 +27,22 @@ public class PresentationConfiguration extends Configuration implements GovukCli
     private String registerDomain = "openregister.org";
 
     @Valid
+    @NotNull
+    @JsonProperty
+    private String registerScheme = "https";
+
+    @Valid
     @JsonProperty
     private boolean enableDownloadResource = false;
 
     @Override
     public String getRegisterDomain() {
         return registerDomain;
+    }
+
+    @Override
+    public String getRegisterScheme() {
+        return registerScheme;
     }
 
     public DataSourceFactory getDatabase() {

--- a/src/main/java/uk/gov/register/presentation/config/RegisterDomainConfiguration.java
+++ b/src/main/java/uk/gov/register/presentation/config/RegisterDomainConfiguration.java
@@ -5,4 +5,5 @@ import org.jvnet.hk2.annotations.Contract;
 @Contract
 public interface RegisterDomainConfiguration {
     String getRegisterDomain();
+    String getRegisterScheme();
 }

--- a/src/main/java/uk/gov/register/presentation/resource/RequestContext.java
+++ b/src/main/java/uk/gov/register/presentation/resource/RequestContext.java
@@ -28,12 +28,12 @@ public class RequestContext {
 
     private final RegistersConfiguration registersConfiguration;
 
-    private final String registerDomain;
+    private final RegisterDomainConfiguration registerDomainConfiguration;
 
     @Inject
     public RequestContext(RegistersConfiguration registersConfiguration, RegisterDomainConfiguration domainConfiguration) {
         this.registersConfiguration = registersConfiguration;
-        this.registerDomain = domainConfiguration.getRegisterDomain();
+        this.registerDomainConfiguration = domainConfiguration;
     }
 
     public String getRegisterPrimaryKey() {
@@ -41,7 +41,7 @@ public class RequestContext {
     }
 
     public String getScheme() {
-        return httpServletRequest.getScheme();
+        return registerDomainConfiguration.getRegisterScheme();
     }
 
     public HttpServletRequest getHttpServletRequest() {
@@ -65,7 +65,7 @@ public class RequestContext {
     }
 
     public String getRegisterDomain() {
-        return registerDomain;
+        return registerDomainConfiguration.getRegisterDomain();
     }
 
     public Optional<String> resourceExtension() {

--- a/src/test/java/uk/gov/register/presentation/representations/TurtleRepresentationWriterTest.java
+++ b/src/test/java/uk/gov/register/presentation/representations/TurtleRepresentationWriterTest.java
@@ -11,6 +11,7 @@ import uk.gov.register.presentation.*;
 import uk.gov.register.presentation.config.Field;
 import uk.gov.register.presentation.config.FieldsConfiguration;
 import uk.gov.register.presentation.config.RegistersConfiguration;
+import uk.gov.register.presentation.config.RegisterDomainConfiguration;
 import uk.gov.register.presentation.dao.Entry;
 import uk.gov.register.presentation.dao.Item;
 import uk.gov.register.presentation.representations.turtle.EntryTurtleWriter;
@@ -46,9 +47,11 @@ public class TurtleRepresentationWriterTest {
 
     @Before
     public void setUp() throws Exception {
-        requestContext = new RequestContext(new RegistersConfiguration(Optional.empty()), () -> "test.register.gov.uk") {
-            @Override
-            public String getScheme() { return "http"; }
+        RegisterDomainConfiguration registerDomainConfiguration = new RegisterDomainConfiguration() {
+                public String getRegisterScheme() { return "http"; }
+                public String getRegisterDomain() { return "test.register.gov.uk"; }
+        };
+        requestContext = new RequestContext(new RegistersConfiguration(Optional.empty()), registerDomainConfiguration) {
             @Override
             public String getRegisterPrimaryKey() { return "address"; }
         };

--- a/src/test/java/uk/gov/register/presentation/resource/EmptyRegisterDomainConfiguration.java
+++ b/src/test/java/uk/gov/register/presentation/resource/EmptyRegisterDomainConfiguration.java
@@ -1,0 +1,11 @@
+package uk.gov.register.presentation.resource;
+
+import uk.gov.register.presentation.config.RegisterDomainConfiguration;
+
+public class EmptyRegisterDomainConfiguration implements RegisterDomainConfiguration {
+    @Override
+    public String getRegisterDomain() { return ""; }
+
+    @Override
+    public String getRegisterScheme() { return ""; }
+}

--- a/src/test/java/uk/gov/register/presentation/resource/RequestContextTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/RequestContextTest.java
@@ -21,7 +21,7 @@ public class RequestContextTest {
 
     @Test
     public void takesRegisterNameFromHttpHost() throws Exception {
-        RequestContext requestContext = new RequestContext(new RegistersConfiguration(Optional.empty()), () -> "");
+        RequestContext requestContext = new RequestContext(new RegistersConfiguration(Optional.empty()), new EmptyRegisterDomainConfiguration());
         requestContext.httpServletRequest = httpServletRequest;
         when(httpServletRequest.getHeader("Host")).thenReturn("school.beta.openregister.org");
 
@@ -32,7 +32,7 @@ public class RequestContextTest {
 
     @Test
     public void behavesGracefullyWhenGivenHostWithNoDots() throws Exception {
-        RequestContext requestContext = new RequestContext(new RegistersConfiguration(Optional.empty()), () -> "");
+        RequestContext requestContext = new RequestContext(new RegistersConfiguration(Optional.empty()), new EmptyRegisterDomainConfiguration());
         requestContext.httpServletRequest = httpServletRequest;
         when(httpServletRequest.getHeader("Host")).thenReturn("school");
 
@@ -43,7 +43,7 @@ public class RequestContextTest {
 
     @Test
     public void resourceExtension_returnsTheResourceExtensionIfExists() {
-        RequestContext requestContext = new RequestContext(new RegistersConfiguration(Optional.empty()), () -> "");
+        RequestContext requestContext = new RequestContext(new RegistersConfiguration(Optional.empty()), new EmptyRegisterDomainConfiguration());
         requestContext.httpServletRequest = httpServletRequest;
         when(httpServletRequest.getRequestURI()).thenReturn("/foo/bar.json");
 
@@ -52,7 +52,7 @@ public class RequestContextTest {
 
     @Test
     public void resourceExtension_returnsEmptyIfResourceExtensionIsNotExists() {
-        RequestContext requestContext = new RequestContext(new RegistersConfiguration(Optional.empty()), () -> "");
+        RequestContext requestContext = new RequestContext(new RegistersConfiguration(Optional.empty()), new EmptyRegisterDomainConfiguration());
         requestContext.httpServletRequest = httpServletRequest;
         when(httpServletRequest.getRequestURI()).thenReturn("/foo/bar");
 

--- a/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
+++ b/src/test/java/uk/gov/register/presentation/resource/SearchResourceTest.java
@@ -29,7 +29,7 @@ public class SearchResourceTest {
 
     @Before
     public void setUp() throws Exception {
-        requestContext = new RequestContext(new RegistersConfiguration(Optional.empty()), () -> ""){
+        requestContext = new RequestContext(new RegistersConfiguration(Optional.empty()), new EmptyRegisterDomainConfiguration()){
             @Override
             public HttpServletResponse getHttpServletResponse() {
                 return servletResponse;

--- a/src/test/resources/test-app-config.yaml
+++ b/src/test/resources/test-app-config.yaml
@@ -8,6 +8,7 @@ server:
       port: 9001
 
 registerDomain: test.register.gov.uk
+registerScheme: http
 
 database:
   driverClass: org.postgresql.Driver


### PR DESCRIPTION
**Please don't merge this yet -- at minimum, we'll need to change all the app config files first**

Currently, we attempt to sniff the register scheme from the request
context.  This fails because the request at the application server may
not use the same scheme as the request at the edge server.  For example,
the app server might be running http, but the edge server might be a CDN
terminating https.

The consequences of this are that absolute URLs are always `http`
urls. In beta, these get automatically converted to `https` (either by
301 redirect or by HSTS in the browser).  These URLs appear both as href
attributes in html links, and as entities and attributes within the
turtle representation.

There are two alternatives to fix this:
- use the X-Forwarded-Proto header to determine what the URI scheme at
  the edge server was
- make the scheme an explicit configuration option

I think the Right Thing is to use X-Forwarded-Proto but that's a bit
more work.  The Easy Thing is to make the scheme an explicit
configuration option and set the config up everywhere.  We can do the
Easy Thing now in order to get correct behaviour, and refactor to the
Right Thing later.

There's a third option which is to use https everywhere -- including in
tests, and when starting it up locally or in a heroku instance or
whatever. I'm not sure I want to go down that road.
